### PR TITLE
Add workaround for Linux AppImage to README.md

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -117,7 +117,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       # TEMPORARY WORKAROUND:
-      # SOURCE: https://github.com/jely2002/youtube-dl-gui/commit/870b91b76c631d07e3c9e52117dc9d2826bb2342
+      # SOURCE: https://github.com/jely2002/youtube-dl-gui/blob/main/.github/workflows/publish.yml
       # Use a custom tauri-cli branch to enable the new "truly portable" AppImage format.
       # This relies on TAURI_BUNDLER_NEW_APPIMAGE_FORMAT=true and can be removed once
       # https://github.com/tauri-apps/tauri/pull/12491 is merged and released upstream.
@@ -127,6 +127,13 @@ jobs:
         run: |
           cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --locked --force
           echo "TAURI_BUNDLER_NEW_APPIMAGE_FORMAT=true" >> $GITHUB_ENV
+
+      # Because we use "cargo tauri" in that tauri build step, we always have to install tauri cli here.
+      - name: Install tauri-cli
+        if: matrix.platform != 'ubuntu-22.04' && matrix.platform != 'ubuntu-22.04-arm'
+        shell: bash
+        run: |
+          cargo install tauri-cli
 
       - name: Build and release
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -116,6 +116,18 @@ jobs:
       - name: Install frontend dependencies
         run: yarn install --frozen-lockfile
 
+      # TEMPORARY WORKAROUND:
+      # SOURCE: https://github.com/jely2002/youtube-dl-gui/commit/870b91b76c631d07e3c9e52117dc9d2826bb2342
+      # Use a custom tauri-cli branch to enable the new "truly portable" AppImage format.
+      # This relies on TAURI_BUNDLER_NEW_APPIMAGE_FORMAT=true and can be removed once
+      # https://github.com/tauri-apps/tauri/pull/12491 is merged and released upstream.
+      - name: Override tauri-cli (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
+        shell: bash
+        run: |
+          cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --locked --force
+          echo "TAURI_BUNDLER_NEW_APPIMAGE_FORMAT=true" >> $GITHUB_ENV
+
       - name: Build and release
         uses: tauri-apps/tauri-action@v0
         timeout-minutes: 60

--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ For feature requests, please see [feature requests](https://github.com/music-ass
 
 > All downloads available on the [Releases page](https://github.com/music-assistant/desktop-app/releases/latest)
 
-> [!NOTE]
-> On Linux you might encounter the error `Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...` when starting the AppImage (via the command line), and you are left with an empty window.
-> Try preloading `/usr/lib/libwayland-client.so` when starting, i.e. `LD_PRELOAD=/usr/lib/libwayland-client.so /path/to/MusicAssistant.AppImage` [Source](https://github.com/jely2002/youtube-dl-gui/issues/603)
-
 ## Features
 
 - **Native Audio Playback** - High-quality audio output via Sendspin protocol with device selection

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ For feature requests, please see [feature requests](https://github.com/music-ass
 
 > All downloads available on the [Releases page](https://github.com/music-assistant/desktop-app/releases/latest)
 
+> [!NOTE]
+> On Linux you might encounter the error ```Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...``` when starting the AppImage (via the command line), and you are left with an empty window.
+> Try preloading ```/usr/lib/libwayland.so``` when starting, i.e. ```LD_PRELOAD=/usr/lib/libwayland-client.so /path/to/MusicAssistant.AppImage``` [Source](https://github.com/jely2002/youtube-dl-gui/issues/603)
+
 ## Features
 
 - **Native Audio Playback** - High-quality audio output via Sendspin protocol with device selection

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For feature requests, please see [feature requests](https://github.com/music-ass
 
 > [!NOTE]
 > On Linux you might encounter the error ```Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...``` when starting the AppImage (via the command line), and you are left with an empty window.
-> Try preloading ```/usr/lib/libwayland.so``` when starting, i.e. ```LD_PRELOAD=/usr/lib/libwayland-client.so /path/to/MusicAssistant.AppImage``` [Source](https://github.com/jely2002/youtube-dl-gui/issues/603)
+> Try preloading ```/usr/lib/libwayland-client.so``` when starting, i.e. ```LD_PRELOAD=/usr/lib/libwayland-client.so /path/to/MusicAssistant.AppImage``` [Source](https://github.com/jely2002/youtube-dl-gui/issues/603)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ For feature requests, please see [feature requests](https://github.com/music-ass
 > All downloads available on the [Releases page](https://github.com/music-assistant/desktop-app/releases/latest)
 
 > [!NOTE]
-> On Linux you might encounter the error ```Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...``` when starting the AppImage (via the command line), and you are left with an empty window.
-> Try preloading ```/usr/lib/libwayland-client.so``` when starting, i.e. ```LD_PRELOAD=/usr/lib/libwayland-client.so /path/to/MusicAssistant.AppImage``` [Source](https://github.com/jely2002/youtube-dl-gui/issues/603)
+> On Linux you might encounter the error `Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...` when starting the AppImage (via the command line), and you are left with an empty window.
+> Try preloading `/usr/lib/libwayland-client.so` when starting, i.e. `LD_PRELOAD=/usr/lib/libwayland-client.so /path/to/MusicAssistant.AppImage` [Source](https://github.com/jely2002/youtube-dl-gui/issues/603)
 
 ## Features
 


### PR DESCRIPTION
I encountered a
```Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...```
when starting the AppImage on my system. I found a workaround [here](https://github.com/jely2002/youtube-dl-gui/issues/603), which works for us as well:
```LD_PRELOAD=/usr/lib/libwayland-client.so /path/to/MusicAssistant.AppImage```

I think adding that to the readme doesn't hurt.

Apparently it is a known tauri issue, and if you use another branch in the build, [see here](https://github.com/jely2002/youtube-dl-gui/commit/870b91b76c631d07e3c9e52117dc9d2826bb2342) it fixes it permanently. But I can't judge if that is applicable for us too.