### PR TITLE
Fix XSS via mDNS server name injection in launcher

### DIFF
--- a/src-tauri/resources/index.html
+++ b/src-tauri/resources/index.html
@@ -432,8 +432,8 @@
           } else {
             serverList.innerHTML = servers
               .map(
-                (server) => `
-                        <div class="server-item" onclick="connectToServer('${escapeHtml(server.url)}', '${escapeHtml(server.name)}')">
+                (server, index) => `
+                        <div class="server-item" data-server-index="${index}">
                             <img src="logo.png" alt="" class="server-icon">
                             <div class="server-info">
                                 <div class="server-name">${escapeHtml(server.name)}</div>
@@ -443,6 +443,11 @@
                     `
               )
               .join("");
+            // Bind click handlers via JS to avoid inline handler injection
+            serverList.querySelectorAll("[data-server-index]").forEach((el) => {
+              const server = servers[parseInt(el.dataset.serverIndex)];
+              el.addEventListener("click", () => connectToServer(server.url, server.name));
+            });
           }
         } catch (e) {
           serverList.innerHTML = `

--- a/src-tauri/resources/index.test.mjs
+++ b/src-tauri/resources/index.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * Regression test for XSS via mDNS server name injection.
+ *
+ * Verifies that the launcher's server list rendering does not
+ * interpolate user-controlled strings into inline event handlers.
+ *
+ * Run: node src-tauri/resources/index.test.mjs
+ */
+
+import { readFileSync } from "fs";
+import { strict as assert } from "assert";
+
+const html = readFileSync(new URL("./index.html", import.meta.url), "utf8");
+
+// ---- Test 1: No inline onclick handlers with interpolated values ----
+// The server list template should NOT contain onclick with escapeHtml
+// interpolation, which is vulnerable to quote-breakout injection.
+const onclickPattern = /onclick="connectToServer\('\$\{escapeHtml/;
+assert.ok(
+  !onclickPattern.test(html),
+  "FAIL: Found inline onclick with escapeHtml interpolation — vulnerable to XSS via quote breakout",
+);
+
+// ---- Test 2: Server items use data attributes + addEventListener ----
+assert.ok(
+  html.includes("data-server-index"),
+  "FAIL: Server items should use data-server-index attributes",
+);
+assert.ok(
+  html.includes("addEventListener"),
+  "FAIL: Click handlers should be bound via addEventListener, not inline onclick",
+);
+
+// ---- Test 3: Simulate the escapeHtml function and verify XSS payloads are inert ----
+// Replicate the browser's textContent/innerHTML escaping behavior
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  // Note: textContent/innerHTML does NOT escape ' " or `
+}
+
+const xssPayloads = [
+  "z');alert(1);('",
+  "z',alert(1),'",
+  'z");alert(1);("',
+  "z`);alert(1);(`",
+  "z');new Image().src=`http://evil.com`;('",
+  "<script>alert(1)</script>",
+  "test' onclick='alert(1)",
+];
+
+for (const payload of xssPayloads) {
+  const escaped = escapeHtml(payload);
+
+  // escapeHtml must neutralize HTML tag injection in element content
+  assert.ok(
+    !escaped.includes("<script>"),
+    `FAIL: escapeHtml did not neutralize script tag in: ${payload}`,
+  );
+}
+
+// ---- Test 4: The template in index.html uses safe integer index, not user content ----
+// Extract the server-item template from the source and verify it only
+// interpolates a numeric index into attributes, never escapeHtml(server.name/url).
+const templateSection = html.slice(
+  html.indexOf(".map("),
+  html.indexOf(".join("),
+);
+
+// The data attribute must use a safe integer index
+assert.ok(
+  templateSection.includes("data-server-index"),
+  "FAIL: Template should use data-server-index for click binding",
+);
+
+// User-controlled values must NOT appear in any HTML attribute context
+// (they should only appear inside element content via escapeHtml)
+const attrPattern = /=["'][^"']*\$\{escapeHtml\(server\.(name|url)\)/;
+assert.ok(
+  !attrPattern.test(templateSection),
+  "FAIL: User-controlled escapeHtml values must not appear in HTML attributes",
+);
+
+console.log("All tests passed.");

--- a/src-tauri/resources/index.test.mjs
+++ b/src-tauri/resources/index.test.mjs
@@ -18,26 +18,23 @@ const html = readFileSync(new URL("./index.html", import.meta.url), "utf8");
 const onclickPattern = /onclick="connectToServer\('\$\{escapeHtml/;
 assert.ok(
   !onclickPattern.test(html),
-  "FAIL: Found inline onclick with escapeHtml interpolation — vulnerable to XSS via quote breakout",
+  "FAIL: Found inline onclick with escapeHtml interpolation — vulnerable to XSS via quote breakout"
 );
 
 // ---- Test 2: Server items use data attributes + addEventListener ----
 assert.ok(
   html.includes("data-server-index"),
-  "FAIL: Server items should use data-server-index attributes",
+  "FAIL: Server items should use data-server-index attributes"
 );
 assert.ok(
   html.includes("addEventListener"),
-  "FAIL: Click handlers should be bound via addEventListener, not inline onclick",
+  "FAIL: Click handlers should be bound via addEventListener, not inline onclick"
 );
 
 // ---- Test 3: Simulate the escapeHtml function and verify XSS payloads are inert ----
 // Replicate the browser's textContent/innerHTML escaping behavior
 function escapeHtml(text) {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
   // Note: textContent/innerHTML does NOT escape ' " or `
 }
 
@@ -57,22 +54,19 @@ for (const payload of xssPayloads) {
   // escapeHtml must neutralize HTML tag injection in element content
   assert.ok(
     !escaped.includes("<script>"),
-    `FAIL: escapeHtml did not neutralize script tag in: ${payload}`,
+    `FAIL: escapeHtml did not neutralize script tag in: ${payload}`
   );
 }
 
 // ---- Test 4: The template in index.html uses safe integer index, not user content ----
 // Extract the server-item template from the source and verify it only
 // interpolates a numeric index into attributes, never escapeHtml(server.name/url).
-const templateSection = html.slice(
-  html.indexOf(".map("),
-  html.indexOf(".join("),
-);
+const templateSection = html.slice(html.indexOf(".map("), html.indexOf(".join("));
 
 // The data attribute must use a safe integer index
 assert.ok(
   templateSection.includes("data-server-index"),
-  "FAIL: Template should use data-server-index for click binding",
+  "FAIL: Template should use data-server-index for click binding"
 );
 
 // User-controlled values must NOT appear in any HTML attribute context
@@ -80,7 +74,7 @@ assert.ok(
 const attrPattern = /=["'][^"']*\$\{escapeHtml\(server\.(name|url)\)/;
 assert.ok(
   !attrPattern.test(templateSection),
-  "FAIL: User-controlled escapeHtml values must not appear in HTML attributes",
+  "FAIL: User-controlled escapeHtml values must not appear in HTML attributes"
 );
 
 console.log("All tests passed.");


### PR DESCRIPTION
Replace inline onclick handlers with addEventListener to prevent JavaScript injection through crafted mDNS service names. The escapeHtml() function only escapes HTML element content characters (<, >, &) but not single quotes, which allowed breaking out of the JS string literal in the onclick attribute context.

Adds regression test that verifies user-controlled values are never interpolated into HTML attributes and that click handlers use addEventListener instead of inline onclick.