### PR TITLE
Fix window lookups that only checked "main", missing "launcher"

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -472,10 +472,13 @@ pub fn run() {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             use tauri::Manager;
 
-            let window = app.get_webview_window("main").expect("no main window");
-
-            window.set_focus().expect("failed to focus window");
-            window.show().expect("failed to show window");
+            if let Some(window) = app
+                .get_webview_window("main")
+                .or_else(|| app.get_webview_window("launcher"))
+            {
+                let _ = window.set_focus();
+                let _ = window.show();
+            }
         }));
     }
 
@@ -621,12 +624,18 @@ pub fn run() {
                         app.exit(0);
                     }
                     "hide" => {
-                        if let Some(window) = app.get_webview_window("main") {
+                        if let Some(window) = app
+                            .get_webview_window("main")
+                            .or_else(|| app.get_webview_window("launcher"))
+                        {
                             let _ = window.hide();
                         }
                     }
                     "show" => {
-                        if let Some(window) = app.get_webview_window("main") {
+                        if let Some(window) = app
+                            .get_webview_window("main")
+                            .or_else(|| app.get_webview_window("launcher"))
+                        {
                             let _ = window.show();
                             let _ = window.set_focus();
                         }
@@ -742,7 +751,10 @@ pub fn run() {
                     }
                     "now_playing" => {
                         // Click on now-playing opens the app
-                        if let Some(window) = app.get_webview_window("main") {
+                        if let Some(window) = app
+                            .get_webview_window("main")
+                            .or_else(|| app.get_webview_window("launcher"))
+                        {
                             let _ = window.show();
                             let _ = window.set_focus();
                         }
@@ -757,7 +769,10 @@ pub fn run() {
                     } = event
                     {
                         let app = tray.app_handle();
-                        if let Some(window) = app.get_webview_window("main") {
+                        if let Some(window) = app
+                            .get_webview_window("main")
+                            .or_else(|| app.get_webview_window("launcher"))
+                        {
                             let _ = window.show();
                             let _ = window.set_focus();
                         }


### PR DESCRIPTION
The app's single webview window alternates names between "main" and "launcher" due to how server switching works: navigate_to_launcher() creates a new window with the opposite name (to avoid Tauri name conflicts) then destroys the old one. Connecting to a server is just an in-place window.location.href navigation — no new window is created.

This means after one "Switch Server" round-trip, the user is fully connected to a server and doing stuff like receiving now_playing data, but the window is named "launcher" (I found this confusing at first, which is why I'm spelling it out). Five code paths only looked up "main":

- Single-instance handler: .expect("no main window") panicked, crashing the app if a second instance was launched and the first instance was not using 'main' for the window name
- Tray "hide"/"show": silently failed
- Tray "now_playing" click: silently failed
- Tray icon left-click: silently failed

Apply the same .or_else(|| get_webview_window("launcher")) pattern already used in 8 other places in this file. Also remove .expect() calls from the single-instance handler in favor of if-let to avoid panics.