### PR TITLE
feat: add software volume control with perceptual curve and ramping

### DIFF
--- a/src-tauri/resources/settings.html
+++ b/src-tauri/resources/settings.html
@@ -236,6 +236,22 @@
       </div>
       <div class="setting-item">
         <div class="setting-label">
+          <span>Volume control</span>
+          <small>How volume is controlled during playback</small>
+        </div>
+        <select
+          id="volume-mode-select"
+          onchange="changeVolumeMode()"
+          title="Hardware volume is faster and higher quality. Software volume should only be used when hardware control is unavailable."
+        >
+          <option value="auto">Auto (hardware with software fallback)</option>
+          <option value="hardware">Hardware only</option>
+          <option value="software">Software only</option>
+          <option value="disabled">Disabled</option>
+        </select>
+      </div>
+      <div class="setting-item">
+        <div class="setting-label">
           <span>Sync delay</span>
           <small>Adjust playback timing for multi-room sync (ms)</small>
         </div>
@@ -337,6 +353,10 @@
           // Load audio devices
           await loadAudioDevices(settings.audio_device_id);
 
+          // Set volume control mode
+          const volumeMode = settings.volume_control_mode || "auto";
+          document.getElementById("volume-mode-select").value = volumeMode;
+
           const version = await invoke("get_app_version");
           document.getElementById("version").textContent = `Music Assistant Companion v${version}`;
         } catch (e) {
@@ -399,6 +419,12 @@
         const select = document.getElementById("audio-device-select");
         const deviceId = select.value || null;
         await invoke("set_string_setting", { key: "audio_device_id", value: deviceId });
+      }
+
+      async function changeVolumeMode() {
+        const select = document.getElementById("volume-mode-select");
+        await invoke("set_string_setting", { key: "volume_control_mode", value: select.value });
+        await invoke("restart_sendspin");
       }
 
       async function changeSyncDelay() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -374,6 +374,13 @@ async fn stop_sendspin() {
     sendspin::stop().await;
 }
 
+/// Restart the Sendspin client
+#[tauri::command]
+async fn restart_sendspin() -> Result<(), String> {
+    sendspin::restart().await;
+    Ok(())
+}
+
 /// Get Sendspin connection status
 #[tauri::command]
 fn get_sendspin_status() -> sendspin::ConnectionStatus {
@@ -511,6 +518,7 @@ pub fn run() {
             // Sendspin commands
             list_audio_devices,
             stop_sendspin,
+            restart_sendspin,
             get_sendspin_status,
             sendspin_command,
             get_sendspin_player_id,

--- a/src-tauri/src/sendspin/mod.rs
+++ b/src-tauri/src/sendspin/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod devices;
 pub mod protocol;
+pub mod software_gain;
 pub mod volume_control;
 
 use crate::now_playing::{self, NowPlaying};
@@ -43,6 +44,12 @@ enum PlayerCommand {
     Clear,
     /// Shutdown the playback thread
     Shutdown,
+    /// Set software volume level (0-100)
+    /// Used by the client loop to send volume commands to the playback thread via `player_tx`
+    SetVolume(u8),
+    /// Set software mute state
+    /// Used by the client loop to send mute commands to the playback thread via `player_tx`
+    SetMute(bool),
 }
 
 /// Auth message for MA proxy
@@ -71,6 +78,53 @@ static CLIENT_TASK: RwLock<Option<tokio::task::JoinHandle<()>>> = RwLock::new(No
 
 /// Hardware volume controller (if available)
 static VOLUME_CONTROLLER: RwLock<Option<VolumeController>> = RwLock::new(None);
+
+/// The resolved volume control behavior for this session.
+/// Determined once at connection time and used for the session duration.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ResolvedVolumeMode {
+    /// Use hardware volume controller
+    Hardware,
+    /// Use software gain processing in the playback thread
+    Software,
+    /// No volume control
+    None,
+}
+
+/// Resolve the user's volume control mode preference against hardware availability.
+///
+/// | Setting  | Hardware available? | Result   |
+/// |----------|-------------------- |----------|
+/// | Auto     | Yes                 | Hardware |
+/// | Auto     | No                  | Software |
+/// | Hardware | Yes                 | Hardware |
+/// | Hardware | No                  | None     |
+/// | Software | N/A                 | Software |
+/// | Disabled | N/A                 | None     |
+fn resolve_volume_mode(
+    mode: &crate::settings::VolumeControlMode,
+    hardware_available: bool,
+) -> ResolvedVolumeMode {
+    use crate::settings::VolumeControlMode;
+    match mode {
+        VolumeControlMode::Auto => {
+            if hardware_available {
+                ResolvedVolumeMode::Hardware
+            } else {
+                ResolvedVolumeMode::Software
+            }
+        }
+        VolumeControlMode::Hardware => {
+            if hardware_available {
+                ResolvedVolumeMode::Hardware
+            } else {
+                ResolvedVolumeMode::None
+            }
+        }
+        VolumeControlMode::Software => ResolvedVolumeMode::Software,
+        VolumeControlMode::Disabled => ResolvedVolumeMode::None,
+    }
+}
 
 /// Client configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -210,49 +264,55 @@ async fn run_client(
         .as_ref()
         .is_some_and(|vc| vc.is_available());
 
+    // Resolve volume control mode from settings
+    let settings = crate::settings::get_settings();
+    let resolved_mode = resolve_volume_mode(&settings.volume_control_mode, has_volume_control);
+
+    eprintln!(
+        "[Sendspin] Volume control: mode={:?}, hardware_available={}, resolved={:?}",
+        settings.volume_control_mode, has_volume_control, resolved_mode
+    );
+
     // Create channel for volume change notifications
     #[allow(unused_mut)] // mut is required for select! macro
     let (volume_change_tx, mut volume_change_rx) = mpsc::channel::<(u8, bool)>(32);
 
-    // Store the volume controller globally and set up change callback
-    if let Some(vc) = volume_controller {
-        // Set up volume change callback
-        // Convert tokio mpsc sender to std mpsc sender for compatibility
-        let (std_tx, std_rx) = std::sync::mpsc::channel::<(u8, bool)>();
+    // Store the volume controller globally and set up change callback only if using hardware mode
+    if resolved_mode == ResolvedVolumeMode::Hardware {
+        if let Some(vc) = volume_controller {
+            // Set up volume change callback
+            // Convert tokio mpsc sender to std mpsc sender for compatibility
+            let (std_tx, std_rx) = std::sync::mpsc::channel::<(u8, bool)>();
 
-        // Spawn a blocking task to forward std mpsc messages to tokio mpsc
-        // std::sync::mpsc::recv() is blocking and must not block the tokio runtime
-        let volume_change_tx_clone = volume_change_tx.clone();
-        tokio::task::spawn_blocking(move || {
-            while let Ok((volume, muted)) = std_rx.recv() {
-                // Use blocking_send since we're in a blocking context
-                let _ = volume_change_tx_clone.blocking_send((volume, muted));
+            // Spawn a blocking task to forward std mpsc messages to tokio mpsc
+            // std::sync::mpsc::recv() is blocking and must not block the tokio runtime
+            let volume_change_tx_clone = volume_change_tx.clone();
+            tokio::task::spawn_blocking(move || {
+                while let Ok((volume, muted)) = std_rx.recv() {
+                    // Use blocking_send since we're in a blocking context
+                    let _ = volume_change_tx_clone.blocking_send((volume, muted));
+                }
+            });
+
+            // Register the callback
+            if let Err(e) = vc.set_change_callback(std_tx) {
+                eprintln!(
+                    "[Sendspin] Failed to register volume change callback: {}",
+                    e
+                );
             }
-        });
 
-        // Register the callback
-        if let Err(e) = vc.set_change_callback(std_tx) {
-            eprintln!(
-                "[Sendspin] Failed to register volume change callback: {}",
-                e
-            );
+            let mut vol_ctrl = VOLUME_CONTROLLER.write();
+            *vol_ctrl = Some(vc);
         }
-
-        let mut vol_ctrl = VOLUME_CONTROLLER.write();
-        *vol_ctrl = Some(vc);
     }
 
-    if has_volume_control {
-        eprintln!("[Sendspin] Hardware volume control is available");
-    } else {
-        eprintln!("[Sendspin] Hardware volume control is not available - volume commands will not be supported");
-    }
-
-    // Build supported commands list - only include volume/mute if hardware control is available
-    let supported_commands = if has_volume_control {
-        vec!["volume".to_string(), "mute".to_string()]
-    } else {
-        vec![]
+    // Build supported commands list based on resolved volume mode
+    let supported_commands = match resolved_mode {
+        ResolvedVolumeMode::Hardware | ResolvedVolumeMode::Software => {
+            vec!["volume".to_string(), "mute".to_string()]
+        }
+        ResolvedVolumeMode::None => vec![],
     };
 
     // Build ClientHello message
@@ -381,6 +441,7 @@ async fn run_client(
         shutdown_rx,
         command_rx,
         volume_change_rx,
+        resolved_mode,
     )
     .await
 }
@@ -391,6 +452,7 @@ type WsStream =
 
 /// Run the Sendspin client on an already-authenticated WebSocket connection
 /// This is used when connecting through the MA proxy which requires auth first
+#[allow(clippy::too_many_arguments)]
 async fn run_authenticated_client(
     mut ws_tx: futures_util::stream::SplitSink<WsStream, WsMessage>,
     mut ws_rx: futures_util::stream::SplitStream<WsStream>,
@@ -399,30 +461,39 @@ async fn run_authenticated_client(
     mut shutdown_rx: mpsc::Receiver<()>,
     mut command_rx: mpsc::Receiver<String>,
     mut volume_change_rx: mpsc::Receiver<(u8, bool)>,
+    resolved_mode: ResolvedVolumeMode,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // Send initial client/state message with current hardware volume
-    let initial_volume = {
-        let vol_ctrl = VOLUME_CONTROLLER.read();
-        if let Some(ref vc) = *vol_ctrl {
-            vc.get_volume().unwrap_or(100)
-        } else {
-            100
+    // Send initial client/state message with current volume
+    let initial_volume = match resolved_mode {
+        ResolvedVolumeMode::Hardware => {
+            let vol_ctrl = VOLUME_CONTROLLER.read();
+            if let Some(ref vc) = *vol_ctrl {
+                vc.get_volume().unwrap_or(100)
+            } else {
+                100
+            }
         }
+        ResolvedVolumeMode::Software | ResolvedVolumeMode::None => 100,
     };
-    let initial_muted = {
-        let vol_ctrl = VOLUME_CONTROLLER.read();
-        if let Some(ref vc) = *vol_ctrl {
-            vc.get_mute().unwrap_or(false)
-        } else {
-            false
+    let initial_muted = match resolved_mode {
+        ResolvedVolumeMode::Hardware => {
+            let vol_ctrl = VOLUME_CONTROLLER.read();
+            if let Some(ref vc) = *vol_ctrl {
+                vc.get_mute().unwrap_or(false)
+            } else {
+                false
+            }
         }
+        ResolvedVolumeMode::Software | ResolvedVolumeMode::None => false,
     };
 
+    let report_volume = (resolved_mode != ResolvedVolumeMode::None).then_some(initial_volume);
+    let report_muted = (resolved_mode != ResolvedVolumeMode::None).then_some(initial_muted);
     let client_state = Message::ClientState(ClientState {
         player: Some(PlayerState {
             state: PlayerSyncState::Synchronized,
-            volume: Some(initial_volume),
-            muted: Some(initial_muted),
+            volume: report_volume,
+            muted: report_muted,
         }),
     });
     let state_json = serde_json::to_string(&client_state)?;
@@ -464,8 +535,14 @@ async fn run_authenticated_client(
 
     // Spawn playback thread that owns the SyncedPlayer
     let clock_sync_for_thread = Arc::clone(&clock_sync);
+    let use_software_volume = resolved_mode == ResolvedVolumeMode::Software;
     let _playback_handle = thread::spawn(move || {
-        run_playback_thread(player_rx, clock_sync_for_thread, device);
+        run_playback_thread(
+            player_rx,
+            clock_sync_for_thread,
+            device,
+            use_software_volume,
+        );
     });
 
     // Message handling variables
@@ -474,27 +551,32 @@ async fn run_authenticated_client(
     let mut endian_locked: Option<PcmEndian> = None;
     let mut playback_started = false;
 
-    // Volume state (synchronized with hardware volume controller)
-    // Try to get initial volume from hardware
-    let mut current_volume: u8 = {
-        let vol_ctrl = VOLUME_CONTROLLER.read();
-        if let Some(ref vc) = *vol_ctrl {
-            vc.get_volume().unwrap_or(100)
-        } else {
-            100
+    // Volume state (synchronized with hardware volume controller or software gain)
+    let mut current_volume: u8 = match resolved_mode {
+        ResolvedVolumeMode::Hardware => {
+            let vol_ctrl = VOLUME_CONTROLLER.read();
+            if let Some(ref vc) = *vol_ctrl {
+                vc.get_volume().unwrap_or(100)
+            } else {
+                100
+            }
         }
+        ResolvedVolumeMode::Software | ResolvedVolumeMode::None => 100,
     };
-    let mut current_muted: bool = {
-        let vol_ctrl = VOLUME_CONTROLLER.read();
-        if let Some(ref vc) = *vol_ctrl {
-            vc.get_mute().unwrap_or(false)
-        } else {
-            false
+    let mut current_muted: bool = match resolved_mode {
+        ResolvedVolumeMode::Hardware => {
+            let vol_ctrl = VOLUME_CONTROLLER.read();
+            if let Some(ref vc) = *vol_ctrl {
+                vc.get_mute().unwrap_or(false)
+            } else {
+                false
+            }
         }
+        ResolvedVolumeMode::Software | ResolvedVolumeMode::None => false,
     };
 
-    // Log initial volume if hardware control is available
-    {
+    // Log initial volume state
+    if resolved_mode == ResolvedVolumeMode::Hardware {
         let vol_ctrl = VOLUME_CONTROLLER.read();
         if vol_ctrl.is_some() {
             eprintln!(
@@ -626,66 +708,91 @@ async fn run_authenticated_client(
                                                 // Handle server command for player control
                                                 if let Some(payload) = generic.get("payload") {
                                                     if let Some(player_cmd) = payload.get("player") {
-                                                        // Handle volume command via hardware volume control
+                                                        // Handle volume command
                                                         if let Some(volume) = player_cmd.get("volume").and_then(|v| v.as_u64()) {
                                                             let vol = (volume as u8).min(100);
 
-                                                            // Use hardware volume controller if available
-                                                            let volume_result = {
-                                                                let vol_ctrl = VOLUME_CONTROLLER.read();
-                                                                if let Some(ref vc) = *vol_ctrl {
-                                                                    vc.set_volume(vol)
-                                                                } else {
-                                                                    Err("Volume controller not available".to_string())
+                                                            let success = match resolved_mode {
+                                                                ResolvedVolumeMode::Hardware => {
+                                                                    let volume_result = {
+                                                                        let vol_ctrl = VOLUME_CONTROLLER.read();
+                                                                        if let Some(ref vc) = *vol_ctrl {
+                                                                            vc.set_volume(vol)
+                                                                        } else {
+                                                                            Err("Volume controller not available".to_string())
+                                                                        }
+                                                                    };
+                                                                    if let Err(e) = &volume_result {
+                                                                        eprintln!("[Sendspin] Failed to set hardware volume: {}", e);
+                                                                    }
+                                                                    volume_result.is_ok()
                                                                 }
-                                                            }; // Lock is released here
+                                                                ResolvedVolumeMode::Software => {
+                                                                    let _ = player_tx.send(PlayerCommand::SetVolume(vol));
+                                                                    true // Software volume always succeeds (command queued)
+                                                                }
+                                                                ResolvedVolumeMode::None => false,
+                                                            };
 
-                                                            if let Err(e) = volume_result {
-                                                                eprintln!("[Sendspin] Failed to set volume: {}", e);
-                                                            } else {
+                                                            if success {
                                                                 current_volume = vol;
-
-                                                                // Send updated state back to server
-                                                                let state = Message::ClientState(ClientState {
-                                                                    player: Some(PlayerState {
-                                                                        state: PlayerSyncState::Synchronized,
-                                                                        volume: Some(current_volume),
-                                                                        muted: Some(current_muted),
-                                                                    }),
-                                                                });
-                                                                if let Ok(json) = serde_json::to_string(&state) {
-                                                                    let _ = ws_tx.send(WsMessage::Text(json.into())).await;
+                                                                // Only echo state back for hardware mode.
+                                                                // Software volume was commanded by the server,
+                                                                // so the server already knows the value. Echoing
+                                                                // it back causes feedback-loop desync during
+                                                                // rapid slider movement.
+                                                                if resolved_mode == ResolvedVolumeMode::Hardware {
+                                                                    let state = Message::ClientState(ClientState {
+                                                                        player: Some(PlayerState {
+                                                                            state: PlayerSyncState::Synchronized,
+                                                                            volume: Some(current_volume),
+                                                                            muted: Some(current_muted),
+                                                                        }),
+                                                                    });
+                                                                    if let Ok(json) = serde_json::to_string(&state) {
+                                                                        let _ = ws_tx.send(WsMessage::Text(json.into())).await;
+                                                                    }
                                                                 }
                                                             }
                                                         }
 
-                                                        // Handle mute command via hardware volume control
+                                                        // Handle mute command
                                                         if let Some(mute) = player_cmd.get("mute").and_then(|v| v.as_bool()) {
-                                                            // Use hardware volume controller if available
-                                                            let mute_result = {
-                                                                let vol_ctrl = VOLUME_CONTROLLER.read();
-                                                                if let Some(ref vc) = *vol_ctrl {
-                                                                    vc.set_mute(mute)
-                                                                } else {
-                                                                    Err("Volume controller not available".to_string())
+                                                            let success = match resolved_mode {
+                                                                ResolvedVolumeMode::Hardware => {
+                                                                    let mute_result = {
+                                                                        let vol_ctrl = VOLUME_CONTROLLER.read();
+                                                                        if let Some(ref vc) = *vol_ctrl {
+                                                                            vc.set_mute(mute)
+                                                                        } else {
+                                                                            Err("Volume controller not available".to_string())
+                                                                        }
+                                                                    };
+                                                                    if let Err(e) = &mute_result {
+                                                                        eprintln!("[Sendspin] Failed to set hardware mute: {}", e);
+                                                                    }
+                                                                    mute_result.is_ok()
                                                                 }
-                                                            }; // Lock is released here
+                                                                ResolvedVolumeMode::Software => {
+                                                                    let _ = player_tx.send(PlayerCommand::SetMute(mute));
+                                                                    true
+                                                                }
+                                                                ResolvedVolumeMode::None => false,
+                                                            };
 
-                                                            if let Err(e) = mute_result {
-                                                                eprintln!("[Sendspin] Failed to set mute: {}", e);
-                                                            } else {
+                                                            if success {
                                                                 current_muted = mute;
-
-                                                                // Send updated state back to server
-                                                                let state = Message::ClientState(ClientState {
-                                                                    player: Some(PlayerState {
-                                                                        state: PlayerSyncState::Synchronized,
-                                                                        volume: Some(current_volume),
-                                                                        muted: Some(current_muted),
-                                                                    }),
-                                                                });
-                                                                if let Ok(json) = serde_json::to_string(&state) {
-                                                                    let _ = ws_tx.send(WsMessage::Text(json.into())).await;
+                                                                if resolved_mode == ResolvedVolumeMode::Hardware {
+                                                                    let state = Message::ClientState(ClientState {
+                                                                        player: Some(PlayerState {
+                                                                            state: PlayerSyncState::Synchronized,
+                                                                            volume: Some(current_volume),
+                                                                            muted: Some(current_muted),
+                                                                        }),
+                                                                    });
+                                                                    if let Ok(json) = serde_json::to_string(&state) {
+                                                                        let _ = ws_tx.send(WsMessage::Text(json.into())).await;
+                                                                    }
                                                                 }
                                                             }
                                                         }
@@ -804,8 +911,10 @@ fn run_playback_thread(
     rx: std_mpsc::Receiver<PlayerCommand>,
     clock_sync: Arc<Mutex<ClockSync>>,
     device: Option<cpal::Device>,
+    use_software_volume: bool,
 ) {
     let mut synced_player: Option<SyncedPlayer> = None;
+    let mut gain_state: Option<software_gain::SoftwareGainState> = None;
 
     loop {
         match rx.recv() {
@@ -816,24 +925,75 @@ fn run_playback_thread(
                 }
 
                 // Create new SyncedPlayer
-                match SyncedPlayer::new(format, Arc::clone(&clock_sync), device.clone()) {
+                match SyncedPlayer::new(format.clone(), Arc::clone(&clock_sync), device.clone()) {
                     Ok(player) => {
                         synced_player = Some(player);
+                        if use_software_volume {
+                            gain_state =
+                                Some(software_gain::SoftwareGainState::new(format.sample_rate));
+                        }
                     }
                     Err(e) => {
                         eprintln!("[Sendspin] Failed to create SyncedPlayer: {}", e);
                     }
                 }
             }
-            Ok(PlayerCommand::Enqueue(buffer)) => {
+            Ok(PlayerCommand::Enqueue(mut buffer)) => {
+                // Drain any pending volume/mute commands so they take
+                // effect on this buffer rather than waiting behind the
+                // entire audio queue.
+                while let Ok(cmd) = rx.try_recv() {
+                    match cmd {
+                        PlayerCommand::SetVolume(v) => {
+                            if let Some(ref mut gs) = gain_state {
+                                gs.set_volume(v);
+                            }
+                        }
+                        PlayerCommand::SetMute(m) => {
+                            if let Some(ref mut gs) = gain_state {
+                                gs.set_mute(m);
+                            }
+                        }
+                        PlayerCommand::Shutdown => {
+                            if let Some(ref player) = synced_player {
+                                player.clear();
+                            }
+                            return;
+                        }
+                        PlayerCommand::Clear => {
+                            if let Some(ref player) = synced_player {
+                                player.clear();
+                            }
+                        }
+                        PlayerCommand::CreatePlayer(_) | PlayerCommand::Enqueue(_) => {
+                            // CreatePlayer won't arrive mid-stream. Enqueue
+                            // can't meaningfully stack here. Stop draining.
+                            break;
+                        }
+                    }
+                }
+
                 if let Some(ref player) = synced_player {
-                    // Enqueue buffer directly - volume control is handled via hardware
+                    if let Some(ref mut gs) = gain_state {
+                        let samples = Arc::make_mut(&mut buffer.samples);
+                        gs.apply_i24(samples);
+                    }
                     player.enqueue(buffer);
                 }
             }
             Ok(PlayerCommand::Clear) => {
                 if let Some(ref player) = synced_player {
                     player.clear();
+                }
+            }
+            Ok(PlayerCommand::SetVolume(volume)) => {
+                if let Some(ref mut gs) = gain_state {
+                    gs.set_volume(volume);
+                }
+            }
+            Ok(PlayerCommand::SetMute(muted)) => {
+                if let Some(ref mut gs) = gain_state {
+                    gs.set_mute(muted);
                 }
             }
             Ok(PlayerCommand::Shutdown) | Err(_) => {
@@ -899,6 +1059,20 @@ pub async fn stop() {
     }
 }
 
+/// Restart the Sendspin client with the existing config.
+/// Used when settings change (e.g., volume control mode, audio device)
+/// to make the new settings take effect immediately.
+/// Does nothing if no client is currently running.
+pub async fn restart() {
+    // Read lock is scoped to this block so it's released before start()
+    // calls stop(), which takes a write lock on SENDSPIN_CLIENT.
+    let config = { SENDSPIN_CLIENT.read().as_ref().map(|c| c.config.clone()) };
+    if let Some(config) = config {
+        log::info!("Restarting Sendspin client to apply new settings");
+        let _ = start(config).await;
+    }
+}
+
 /// Send a playback command (play, pause, stop, next, previous)
 pub fn send_command(command: &str) -> Result<(), String> {
     let client = SENDSPIN_CLIENT.read();
@@ -916,5 +1090,67 @@ pub fn send_command(command: &str) -> Result<(), String> {
         Ok(())
     } else {
         Err("Command channel not available".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::VolumeControlMode;
+
+    #[test]
+    fn resolve_volume_mode_auto_with_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Auto, true),
+            ResolvedVolumeMode::Hardware
+        );
+    }
+
+    #[test]
+    fn resolve_volume_mode_auto_without_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Auto, false),
+            ResolvedVolumeMode::Software
+        );
+    }
+
+    #[test]
+    fn resolve_volume_mode_hardware_with_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Hardware, true),
+            ResolvedVolumeMode::Hardware
+        );
+    }
+
+    #[test]
+    fn resolve_volume_mode_hardware_without_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Hardware, false),
+            ResolvedVolumeMode::None
+        );
+    }
+
+    #[test]
+    fn resolve_volume_mode_software_ignores_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Software, true),
+            ResolvedVolumeMode::Software
+        );
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Software, false),
+            ResolvedVolumeMode::Software
+        );
+    }
+
+    #[test]
+    fn resolve_volume_mode_disabled_ignores_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Disabled, true),
+            ResolvedVolumeMode::None
+        );
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Disabled, false),
+            ResolvedVolumeMode::None
+        );
     }
 }

--- a/src-tauri/src/sendspin/software_gain.rs
+++ b/src-tauri/src/sendspin/software_gain.rs
@@ -1,0 +1,475 @@
+//! Software volume control via gain processing applied to PCM audio samples.
+//!
+//! Applies a gain factor to audio buffers in-place before they reach the audio device.
+//! Supports smooth ramping between gain levels to avoid audible clicks.
+
+use sendspin::audio::Sample;
+
+/// Convert a 0-100 volume percentage to a gain factor using a perceptual power curve.
+///
+/// Uses `(volume / 100.0).powi(4)` which provides ~60dB dynamic range.
+/// - Volume 0 → gain 0.0 (silence)
+/// - Volume 100 → gain 1.0 (unity, no change)
+pub fn volume_to_gain(volume: u8) -> f32 {
+    let normalized = f32::from(volume.min(100)) / 100.0;
+    normalized.powi(4)
+}
+
+/// Tracks the current gain state for software volume processing.
+///
+/// Created once per playback session. Updated when volume/mute commands arrive.
+/// Called on every audio buffer to apply gain before enqueue.
+pub struct SoftwareGainState {
+    /// The gain factor currently being applied
+    current_gain: f32,
+    /// The gain factor we're ramping toward
+    target_gain: f32,
+    /// Number of samples remaining in the current ramp (0 = no ramp active)
+    ramp_samples_remaining: u32,
+    /// Per-sample increment during ramp (can be negative for decreasing gain)
+    ramp_step: f32,
+    /// Whether muted (gain forced to 0, volume remembered for unmute)
+    is_muted: bool,
+    /// The volume level (0-100) — remembered separately from mute state
+    volume: u8,
+    /// Total ramp duration in samples, calculated from sample rate
+    ramp_duration_samples: u32,
+}
+
+impl SoftwareGainState {
+    /// Create a new gain state with the given sample rate.
+    /// Starts at volume 100 (unity gain, no modification).
+    pub fn new(sample_rate: u32) -> Self {
+        // ~20ms ramp duration
+        let ramp_duration_samples = (sample_rate as f32 * 0.020) as u32;
+        Self {
+            current_gain: 1.0,
+            target_gain: 1.0,
+            ramp_samples_remaining: 0,
+            ramp_step: 0.0,
+            is_muted: false,
+            volume: 100,
+            ramp_duration_samples,
+        }
+    }
+
+    /// Set the volume level (0-100). Starts a ramp to the new gain.
+    pub fn set_volume(&mut self, volume: u8) {
+        self.volume = volume;
+        if !self.is_muted {
+            self.set_target_gain(volume_to_gain(volume));
+        }
+    }
+
+    /// Set mute state. Muting ramps to silence; unmuting ramps back to current volume.
+    pub fn set_mute(&mut self, muted: bool) {
+        self.is_muted = muted;
+        if muted {
+            self.set_target_gain(0.0);
+        } else {
+            self.set_target_gain(volume_to_gain(self.volume));
+        }
+    }
+
+    /// Returns the current volume level (0-100), independent of mute state.
+    #[cfg(test)]
+    pub fn volume(&self) -> u8 {
+        self.volume
+    }
+
+    /// Apply gain to a buffer of f32 samples in-place.
+    /// Handles ramping if a gain transition is in progress.
+    #[cfg(test)]
+    pub fn apply(&mut self, samples: &mut [f32]) {
+        // Fast path: no ramp active and gain is unity — skip processing entirely
+        if self.ramp_samples_remaining == 0 && (self.current_gain - 1.0).abs() < f32::EPSILON {
+            return;
+        }
+
+        // Fast path: no ramp active and gain is zero — zero the buffer
+        if self.ramp_samples_remaining == 0 && self.current_gain.abs() < f32::EPSILON {
+            for sample in samples.iter_mut() {
+                *sample = 0.0;
+            }
+            return;
+        }
+
+        // Fast path: no ramp active — constant gain multiply
+        if self.ramp_samples_remaining == 0 {
+            for sample in samples.iter_mut() {
+                *sample *= self.current_gain;
+            }
+            return;
+        }
+
+        // Ramp path: per-sample gain interpolation
+        for sample in samples.iter_mut() {
+            *sample *= self.current_gain;
+
+            if self.ramp_samples_remaining > 0 {
+                self.ramp_samples_remaining -= 1;
+                if self.ramp_samples_remaining == 0 {
+                    // Ramp complete — snap to target to avoid floating point drift
+                    self.current_gain = self.target_gain;
+                } else {
+                    self.current_gain += self.ramp_step;
+                }
+            }
+        }
+    }
+
+    /// Apply gain to a buffer of 24-bit signed integer samples in-place.
+    /// Handles ramping if a gain transition is in progress.
+    /// Clamps results to the valid range for 24-bit signed integers (Sample).
+    pub fn apply_i24(&mut self, samples: &mut [Sample]) {
+        // Fast path: no ramp active and gain is unity — skip processing entirely
+        if self.ramp_samples_remaining == 0 && (self.current_gain - 1.0).abs() < f32::EPSILON {
+            return;
+        }
+
+        // Fast path: no ramp active and gain is zero — zero the buffer
+        if self.ramp_samples_remaining == 0 && self.current_gain.abs() < f32::EPSILON {
+            for sample in samples.iter_mut() {
+                *sample = Sample(0);
+            }
+            return;
+        }
+
+        // Fast path: no ramp active — constant gain multiply with clamping
+        if self.ramp_samples_remaining == 0 {
+            for sample in samples.iter_mut() {
+                let value = sample.0 as f32 * self.current_gain;
+                let clamped = clamp_i24(value);
+                *sample = Sample(clamped);
+            }
+            return;
+        }
+
+        // Ramp path: per-sample gain interpolation with clamping
+        for sample in samples.iter_mut() {
+            let value = sample.0 as f32 * self.current_gain;
+            let clamped = clamp_i24(value);
+            *sample = Sample(clamped);
+
+            if self.ramp_samples_remaining > 0 {
+                self.ramp_samples_remaining -= 1;
+                if self.ramp_samples_remaining == 0 {
+                    // Ramp complete — snap to target to avoid floating point drift
+                    self.current_gain = self.target_gain;
+                } else {
+                    self.current_gain += self.ramp_step;
+                }
+            }
+        }
+    }
+
+    /// Start a ramp from current gain to the given target.
+    fn set_target_gain(&mut self, target: f32) {
+        self.target_gain = target;
+
+        if self.ramp_duration_samples == 0 {
+            // No ramping (e.g., sample rate not yet known)
+            self.current_gain = target;
+            self.ramp_samples_remaining = 0;
+            return;
+        }
+
+        let diff = target - self.current_gain;
+        if diff.abs() < f32::EPSILON {
+            // Already at target
+            self.ramp_samples_remaining = 0;
+            return;
+        }
+
+        self.ramp_samples_remaining = self.ramp_duration_samples;
+        self.ramp_step = diff / self.ramp_duration_samples as f32;
+    }
+}
+
+/// Clamp a floating-point value to the valid range for 24-bit signed integers.
+/// 24-bit signed: -8388608 to 8388607
+fn clamp_i24(value: f32) -> i32 {
+    const MIN_I24: i32 = -8388608;
+    const MAX_I24: i32 = 8388607;
+    if value.is_nan() {
+        0
+    } else if value <= MIN_I24 as f32 {
+        MIN_I24
+    } else if value >= MAX_I24 as f32 {
+        MAX_I24
+    } else {
+        value.round() as i32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn volume_to_gain_boundaries() {
+        // AC3.1: Volume 100 → unity gain
+        #[allow(clippy::float_cmp)]
+        {
+            assert_eq!(volume_to_gain(100), 1.0);
+            // AC3.2: Volume 0 → silence
+            assert_eq!(volume_to_gain(0), 0.0);
+        }
+    }
+
+    #[test]
+    fn volume_to_gain_intermediate() {
+        // AC3.3: Intermediate values follow power curve
+        let gain_50 = volume_to_gain(50);
+        assert!(
+            (gain_50 - 0.0625).abs() < 0.001,
+            "50% should be ~0.0625, got {}",
+            gain_50
+        );
+
+        // Monotonically increasing
+        let mut prev = 0.0f32;
+        for v in 1..=100 {
+            let g = volume_to_gain(v);
+            assert!(
+                g > prev,
+                "gain should increase: vol={}, gain={}, prev={}",
+                v,
+                g,
+                prev
+            );
+            prev = g;
+        }
+    }
+
+    #[test]
+    fn volume_to_gain_clamps_above_100() {
+        // Values above 100 should clamp to 100
+        #[allow(clippy::float_cmp)]
+        {
+            assert_eq!(volume_to_gain(255), 1.0);
+        }
+    }
+
+    #[test]
+    fn apply_unity_gain_is_noop() {
+        // AC3.1: Volume 100 does not modify samples
+        let mut state = SoftwareGainState::new(48000);
+        let original = vec![0.5, -0.3, 1.0, -1.0, 0.0];
+        let mut samples = original.clone();
+        state.apply(&mut samples);
+        assert_eq!(samples, original);
+    }
+
+    #[test]
+    fn apply_zero_volume_produces_silence() {
+        // AC3.2: Volume 0 produces all-zero samples
+        let mut state = SoftwareGainState::new(48000);
+        state.set_volume(0);
+        // Exhaust the ramp first
+        let mut ramp_buf = vec![0.0f32; 48000];
+        state.apply(&mut ramp_buf);
+        // Now apply to actual samples
+        let mut samples = vec![0.5, -0.3, 1.0, -1.0, 0.123];
+        state.apply(&mut samples);
+        #[allow(clippy::float_cmp)]
+        {
+            for s in &samples {
+                assert_eq!(*s, 0.0);
+            }
+        }
+    }
+
+    #[test]
+    fn apply_intermediate_volume() {
+        // AC3.3: Intermediate volume scales by gain factor
+        let mut state = SoftwareGainState::new(48000);
+        state.set_volume(50);
+        // Exhaust ramp
+        let mut ramp_buf = vec![0.0f32; 48000];
+        state.apply(&mut ramp_buf);
+        // Apply to samples
+        let gain = volume_to_gain(50);
+        let mut samples = vec![1.0, -1.0, 0.5];
+        state.apply(&mut samples);
+        assert!((samples[0] - gain).abs() < 1e-6);
+        assert!((samples[1] - (-gain)).abs() < 1e-6);
+        assert!((samples[2] - 0.5 * gain).abs() < 1e-6);
+    }
+
+    #[test]
+    fn ramp_produces_smooth_transition() {
+        // AC3.4: Gain changes ramp over ~20ms
+        let sample_rate = 48000u32;
+        let mut state = SoftwareGainState::new(sample_rate);
+        state.set_volume(0); // Ramp from 1.0 to 0.0
+
+        let ramp_samples = (sample_rate as f32 * 0.020) as usize;
+        let mut samples = vec![1.0f32; ramp_samples + 100];
+        state.apply(&mut samples);
+
+        // First sample should still be close to 1.0 (start of ramp)
+        assert!(
+            samples[0] > 0.9,
+            "first sample should be near unity: {}",
+            samples[0]
+        );
+
+        // Mid-ramp sample should be between 0 and 1
+        let mid = ramp_samples / 2;
+        assert!(
+            samples[mid] > 0.0 && samples[mid] < 1.0,
+            "mid-ramp should be intermediate: {}",
+            samples[mid]
+        );
+
+        // After ramp completes, samples should be 0
+        assert!(
+            (samples[ramp_samples + 50]).abs() < 1e-6,
+            "post-ramp should be zero: {}",
+            samples[ramp_samples + 50]
+        );
+
+        // Check monotonically decreasing during ramp
+        for i in 1..ramp_samples {
+            assert!(
+                samples[i] <= samples[i - 1] + 1e-6,
+                "ramp should be monotonically decreasing at sample {}",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn mute_and_unmute() {
+        // AC3.5: Mute sets gain to zero; unmute restores previous volume
+        let mut state = SoftwareGainState::new(48000);
+        state.set_volume(50);
+        // Exhaust ramp
+        let mut buf = vec![0.0f32; 48000];
+        state.apply(&mut buf);
+
+        // Mute
+        state.set_mute(true);
+        let mut buf = vec![0.0f32; 48000];
+        state.apply(&mut buf);
+        let mut samples = vec![1.0; 10];
+        state.apply(&mut samples);
+        #[allow(clippy::float_cmp)]
+        {
+            for s in &samples {
+                assert_eq!(*s, 0.0, "muted samples should be zero");
+            }
+        }
+
+        // Unmute — should restore volume 50
+        state.set_mute(false);
+        let mut buf = vec![0.0f32; 48000];
+        state.apply(&mut buf);
+        let gain = volume_to_gain(50);
+        let mut samples = vec![1.0; 10];
+        state.apply(&mut samples);
+        for s in &samples {
+            assert!(
+                (*s - gain).abs() < 1e-6,
+                "unmuted should restore gain: {}",
+                s
+            );
+        }
+        assert_eq!(state.volume(), 50);
+    }
+
+    #[test]
+    fn unity_gain_does_not_modify_samples() {
+        // Verifies that apply() at unity gain (volume 100) is a true no-op.
+        // This supports AC3.1 (volume 100 = unchanged samples) and is also the
+        // foundation for AC3.6: in Hardware mode, the playback thread never creates
+        // a SoftwareGainState or calls apply() — that conditional logic is in Task 2.
+        let mut state = SoftwareGainState::new(48000);
+        let original = vec![0.5, -0.3, 1.0, -1.0, 0.0, 0.999, -0.999];
+        let mut samples = original.clone();
+        state.apply(&mut samples);
+        assert_eq!(
+            samples, original,
+            "unity gain state must not modify samples"
+        );
+    }
+
+    #[test]
+    fn apply_i24_unity_gain_is_noop() {
+        // Verifies that apply_i24() at unity gain (volume 100) leaves samples unchanged
+        let mut state = SoftwareGainState::new(48000);
+        let original = vec![
+            Sample(1000),
+            Sample(-1000),
+            Sample(8388607),
+            Sample(-8388608),
+            Sample(0),
+        ];
+        let mut samples = original.clone();
+        state.apply_i24(&mut samples);
+        assert_eq!(
+            samples, original,
+            "unity gain should not modify i24 samples"
+        );
+    }
+
+    #[test]
+    fn apply_i24_zero_volume_produces_silence() {
+        // Verifies that apply_i24() at volume 0 produces all-zero samples
+        let mut state = SoftwareGainState::new(48000);
+        state.set_volume(0);
+        // Exhaust the ramp first
+        let mut ramp_buf = vec![Sample(0); 48000];
+        state.apply_i24(&mut ramp_buf);
+        // Now apply to actual samples
+        let mut samples = vec![
+            Sample(1000),
+            Sample(-1000),
+            Sample(5000),
+            Sample(-5000),
+            Sample(123),
+        ];
+        state.apply_i24(&mut samples);
+        for s in &samples {
+            assert_eq!(s.0, 0, "zero volume should produce silence");
+        }
+    }
+
+    #[test]
+    fn apply_i24_clamps_overflow() {
+        const MAX_I24: i32 = 8388607;
+        const MIN_I24: i32 = -8388608;
+
+        // Verifies that apply_i24() clamps results to 24-bit range
+        let mut state = SoftwareGainState::new(48000);
+        state.set_volume(100); // unity gain first
+        let mut ramp_buf = vec![Sample(0); 48000];
+        state.apply_i24(&mut ramp_buf);
+
+        // Now test with intermediate gain (50% volume)
+        state.set_volume(50);
+        let mut ramp_buf = vec![Sample(0); 48000];
+        state.apply_i24(&mut ramp_buf);
+
+        // Test with a sample that would overflow if not clamped
+        let mut samples = vec![Sample(i32::MAX)];
+        state.apply_i24(&mut samples);
+
+        // The result should be clamped to MAX_I24
+        assert!(
+            samples[0].0 <= MAX_I24,
+            "apply_i24 should clamp to MAX_I24, got {}",
+            samples[0].0
+        );
+
+        // Similarly, test negative overflow
+        let mut samples = vec![Sample(i32::MIN)];
+        state.apply_i24(&mut samples);
+        assert!(
+            samples[0].0 >= MIN_I24,
+            "apply_i24 should clamp to MIN_I24, got {}",
+            samples[0].0
+        );
+    }
+}


### PR DESCRIPTION
Add configurable volume control mode (Auto/Hardware/Software/Disabled) that resolves at connection time based on user preference and hardware availability. Software mode applies a perceptual power curve ((vol/100)^4) with 20ms linear ramping to prevent clicks.

- VolumeControlMode enum with Auto default, persisted in settings JSON
- ResolvedVolumeMode (Hardware/Software/None) resolved once per session
- SoftwareGainState: gain curve, ramp smoothing, i24 PCM sample processing
- Volume/mute commands routed by resolved mode
- Software mode skips state echo to server (prevents feedback-loop desync)
- Drain pending volume commands before each buffer enqueue (reduces latency)
- Settings UI dropdown with immediate reconnect on change
- 21 automated tests, human test plan (which I did thoroughly)

Known limitation: gain applied at enqueue time, not playback time. SyncedPlayer buffers ~2s ahead, so software volume changes have latency until/unless sendspin-rs adds a post-processing callback. I added a tool-tip to that effect.