### PR TITLE
Use sendspin built-in volume control for instant response

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4173,7 +4173,6 @@ dependencies = [
 [[package]]
 name = "sendspin"
 version = "0.1.0"
-source = "git+https://github.com/Sendspin/sendspin-rs?branch=main#fbc467a0ee6f9e3f1b354a9949c5182bc37f2d04"
 dependencies = [
  "cpal",
  "crossbeam",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4173,6 +4173,7 @@ dependencies = [
 [[package]]
 name = "sendspin"
 version = "0.1.0"
+source = "git+https://github.com/Sendspin/sendspin-rs?branch=main#6c105df3b0e5dc89a190b146917d1ee51973abc5"
 dependencies = [
  "cpal",
  "crossbeam",
@@ -4184,6 +4185,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite 0.24.0",
+ "typed-builder",
  "uuid 1.19.0",
 ]
 
@@ -5521,6 +5523,26 @@ dependencies = [
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ futures-util = "0.3"
 hostname = "0.4"
 parking_lot = "0.12"
 png = "0.17"
-sendspin = {path = "/Users/davidbishop/Development/sendspin-rs"}
+sendspin = {git = "https://github.com/Sendspin/sendspin-rs", branch = "main"}
 tokio = {version = "1", features = ["sync", "macros", "time"] }
 tokio-tungstenite = "0.26"
 uuid = {version = "1", features = ["v4"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ futures-util = "0.3"
 hostname = "0.4"
 parking_lot = "0.12"
 png = "0.17"
-sendspin = {git = "https://github.com/Sendspin/sendspin-rs", branch = "main"}
+sendspin = {path = "/Users/davidbishop/Development/sendspin-rs"}
 tokio = {version = "1", features = ["sync", "macros", "time"] }
 tokio-tungstenite = "0.26"
 uuid = {version = "1", features = ["v4"] }

--- a/src-tauri/resources/settings.html
+++ b/src-tauri/resources/settings.html
@@ -236,6 +236,22 @@
       </div>
       <div class="setting-item">
         <div class="setting-label">
+          <span>Volume control</span>
+          <small>How volume is controlled during playback</small>
+        </div>
+        <select
+          id="volume-mode-select"
+          onchange="changeVolumeMode()"
+          title="Hardware volume is faster and higher quality. Software volume should only be used when hardware control is unavailable."
+        >
+          <option value="auto">Auto (hardware with software fallback)</option>
+          <option value="hardware">Hardware only</option>
+          <option value="software">Software only</option>
+          <option value="disabled">Disabled</option>
+        </select>
+      </div>
+      <div class="setting-item">
+        <div class="setting-label">
           <span>Sync delay</span>
           <small>Adjust playback timing for multi-room sync (ms)</small>
         </div>
@@ -337,6 +353,10 @@
           // Load audio devices
           await loadAudioDevices(settings.audio_device_id);
 
+          // Set volume control mode
+          const volumeMode = settings.volume_control_mode || "auto";
+          document.getElementById("volume-mode-select").value = volumeMode;
+
           const version = await invoke("get_app_version");
           document.getElementById("version").textContent = `Music Assistant Companion v${version}`;
         } catch (e) {
@@ -399,6 +419,12 @@
         const select = document.getElementById("audio-device-select");
         const deviceId = select.value || null;
         await invoke("set_string_setting", { key: "audio_device_id", value: deviceId });
+      }
+
+      async function changeVolumeMode() {
+        const select = document.getElementById("volume-mode-select");
+        await invoke("set_string_setting", { key: "volume_control_mode", value: select.value });
+        await invoke("restart_sendspin");
       }
 
       async function changeSyncDelay() {

--- a/src-tauri/resources/settings.html
+++ b/src-tauri/resources/settings.html
@@ -237,7 +237,10 @@
       <div class="setting-item">
         <div class="setting-label">
           <span>Volume control</span>
-          <small>How volume is controlled during playback</small>
+          <small
+            >How volume is controlled during playback. Changing this will briefly interrupt
+            playback.</small
+          >
         </div>
         <select
           id="volume-mode-select"
@@ -355,7 +358,9 @@
 
           // Set volume control mode
           const volumeMode = settings.volume_control_mode || "auto";
-          document.getElementById("volume-mode-select").value = volumeMode;
+          const volumeSelect = document.getElementById("volume-mode-select");
+          volumeSelect.value = volumeMode;
+          volumeSelect.dataset.previous = volumeMode;
 
           const version = await invoke("get_app_version");
           document.getElementById("version").textContent = `Music Assistant Companion v${version}`;
@@ -423,8 +428,15 @@
 
       async function changeVolumeMode() {
         const select = document.getElementById("volume-mode-select");
-        await invoke("set_string_setting", { key: "volume_control_mode", value: select.value });
-        await invoke("restart_sendspin");
+        const previous = select.dataset.previous;
+        try {
+          await invoke("set_string_setting", { key: "volume_control_mode", value: select.value });
+          await invoke("restart_sendspin");
+          select.dataset.previous = select.value;
+        } catch (e) {
+          console.error("[Settings] Failed to change volume mode:", e);
+          select.value = previous;
+        }
       }
 
       async function changeSyncDelay() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -374,6 +374,13 @@ async fn stop_sendspin() {
     sendspin::stop().await;
 }
 
+/// Restart the Sendspin client
+#[tauri::command]
+async fn restart_sendspin() -> Result<(), String> {
+    sendspin::restart().await;
+    Ok(())
+}
+
 /// Get Sendspin connection status
 #[tauri::command]
 fn get_sendspin_status() -> sendspin::ConnectionStatus {
@@ -511,6 +518,7 @@ pub fn run() {
             // Sendspin commands
             list_audio_devices,
             stop_sendspin,
+            restart_sendspin,
             get_sendspin_status,
             sendspin_command,
             get_sendspin_player_id,

--- a/src-tauri/src/sendspin/mod.rs
+++ b/src-tauri/src/sendspin/mod.rs
@@ -43,6 +43,12 @@ enum PlayerCommand {
     Clear,
     /// Shutdown the playback thread
     Shutdown,
+    /// Set software volume level (0-100)
+    /// Used by the client loop to send volume commands to the playback thread via `player_tx`
+    SetVolume(u8),
+    /// Set software mute state
+    /// Used by the client loop to send mute commands to the playback thread via `player_tx`
+    SetMute(bool),
 }
 
 /// Auth message for MA proxy
@@ -71,6 +77,53 @@ static CLIENT_TASK: RwLock<Option<tokio::task::JoinHandle<()>>> = RwLock::new(No
 
 /// Hardware volume controller (if available)
 static VOLUME_CONTROLLER: RwLock<Option<VolumeController>> = RwLock::new(None);
+
+/// The resolved volume control behavior for this session.
+/// Determined once at connection time and used for the session duration.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ResolvedVolumeMode {
+    /// Use hardware volume controller
+    Hardware,
+    /// Use software gain processing in the playback thread
+    Software,
+    /// No volume control
+    None,
+}
+
+/// Resolve the user's volume control mode preference against hardware availability.
+///
+/// | Setting  | Hardware available? | Result   |
+/// |----------|-------------------- |----------|
+/// | Auto     | Yes                 | Hardware |
+/// | Auto     | No                  | Software |
+/// | Hardware | Yes                 | Hardware |
+/// | Hardware | No                  | None     |
+/// | Software | N/A                 | Software |
+/// | Disabled | N/A                 | None     |
+fn resolve_volume_mode(
+    mode: &crate::settings::VolumeControlMode,
+    hardware_available: bool,
+) -> ResolvedVolumeMode {
+    use crate::settings::VolumeControlMode;
+    match mode {
+        VolumeControlMode::Auto => {
+            if hardware_available {
+                ResolvedVolumeMode::Hardware
+            } else {
+                ResolvedVolumeMode::Software
+            }
+        }
+        VolumeControlMode::Hardware => {
+            if hardware_available {
+                ResolvedVolumeMode::Hardware
+            } else {
+                ResolvedVolumeMode::None
+            }
+        }
+        VolumeControlMode::Software => ResolvedVolumeMode::Software,
+        VolumeControlMode::Disabled => ResolvedVolumeMode::None,
+    }
+}
 
 /// Client configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -210,49 +263,55 @@ async fn run_client(
         .as_ref()
         .is_some_and(|vc| vc.is_available());
 
+    // Resolve volume control mode from settings
+    let settings = crate::settings::get_settings();
+    let resolved_mode = resolve_volume_mode(&settings.volume_control_mode, has_volume_control);
+
+    eprintln!(
+        "[Sendspin] Volume control: mode={:?}, hardware_available={}, resolved={:?}",
+        settings.volume_control_mode, has_volume_control, resolved_mode
+    );
+
     // Create channel for volume change notifications
     #[allow(unused_mut)] // mut is required for select! macro
     let (volume_change_tx, mut volume_change_rx) = mpsc::channel::<(u8, bool)>(32);
 
-    // Store the volume controller globally and set up change callback
-    if let Some(vc) = volume_controller {
-        // Set up volume change callback
-        // Convert tokio mpsc sender to std mpsc sender for compatibility
-        let (std_tx, std_rx) = std::sync::mpsc::channel::<(u8, bool)>();
+    // Store the volume controller globally and set up change callback only if using hardware mode
+    if resolved_mode == ResolvedVolumeMode::Hardware {
+        if let Some(vc) = volume_controller {
+            // Set up volume change callback
+            // Convert tokio mpsc sender to std mpsc sender for compatibility
+            let (std_tx, std_rx) = std::sync::mpsc::channel::<(u8, bool)>();
 
-        // Spawn a blocking task to forward std mpsc messages to tokio mpsc
-        // std::sync::mpsc::recv() is blocking and must not block the tokio runtime
-        let volume_change_tx_clone = volume_change_tx.clone();
-        tokio::task::spawn_blocking(move || {
-            while let Ok((volume, muted)) = std_rx.recv() {
-                // Use blocking_send since we're in a blocking context
-                let _ = volume_change_tx_clone.blocking_send((volume, muted));
+            // Spawn a blocking task to forward std mpsc messages to tokio mpsc
+            // std::sync::mpsc::recv() is blocking and must not block the tokio runtime
+            let volume_change_tx_clone = volume_change_tx.clone();
+            tokio::task::spawn_blocking(move || {
+                while let Ok((volume, muted)) = std_rx.recv() {
+                    // Use blocking_send since we're in a blocking context
+                    let _ = volume_change_tx_clone.blocking_send((volume, muted));
+                }
+            });
+
+            // Register the callback
+            if let Err(e) = vc.set_change_callback(std_tx) {
+                eprintln!(
+                    "[Sendspin] Failed to register volume change callback: {}",
+                    e
+                );
             }
-        });
 
-        // Register the callback
-        if let Err(e) = vc.set_change_callback(std_tx) {
-            eprintln!(
-                "[Sendspin] Failed to register volume change callback: {}",
-                e
-            );
+            let mut vol_ctrl = VOLUME_CONTROLLER.write();
+            *vol_ctrl = Some(vc);
         }
-
-        let mut vol_ctrl = VOLUME_CONTROLLER.write();
-        *vol_ctrl = Some(vc);
     }
 
-    if has_volume_control {
-        eprintln!("[Sendspin] Hardware volume control is available");
-    } else {
-        eprintln!("[Sendspin] Hardware volume control is not available - volume commands will not be supported");
-    }
-
-    // Build supported commands list - only include volume/mute if hardware control is available
-    let supported_commands = if has_volume_control {
-        vec!["volume".to_string(), "mute".to_string()]
-    } else {
-        vec![]
+    // Build supported commands list based on resolved volume mode
+    let supported_commands = match resolved_mode {
+        ResolvedVolumeMode::Hardware | ResolvedVolumeMode::Software => {
+            vec!["volume".to_string(), "mute".to_string()]
+        }
+        ResolvedVolumeMode::None => vec![],
     };
 
     // Build ClientHello message
@@ -381,6 +440,7 @@ async fn run_client(
         shutdown_rx,
         command_rx,
         volume_change_rx,
+        resolved_mode,
     )
     .await
 }
@@ -391,6 +451,7 @@ type WsStream =
 
 /// Run the Sendspin client on an already-authenticated WebSocket connection
 /// This is used when connecting through the MA proxy which requires auth first
+#[allow(clippy::too_many_arguments)]
 async fn run_authenticated_client(
     mut ws_tx: futures_util::stream::SplitSink<WsStream, WsMessage>,
     mut ws_rx: futures_util::stream::SplitStream<WsStream>,
@@ -399,30 +460,39 @@ async fn run_authenticated_client(
     mut shutdown_rx: mpsc::Receiver<()>,
     mut command_rx: mpsc::Receiver<String>,
     mut volume_change_rx: mpsc::Receiver<(u8, bool)>,
+    resolved_mode: ResolvedVolumeMode,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // Send initial client/state message with current hardware volume
-    let initial_volume = {
-        let vol_ctrl = VOLUME_CONTROLLER.read();
-        if let Some(ref vc) = *vol_ctrl {
-            vc.get_volume().unwrap_or(100)
-        } else {
-            100
+    // Send initial client/state message with current volume
+    let initial_volume = match resolved_mode {
+        ResolvedVolumeMode::Hardware => {
+            let vol_ctrl = VOLUME_CONTROLLER.read();
+            if let Some(ref vc) = *vol_ctrl {
+                vc.get_volume().unwrap_or(100)
+            } else {
+                100
+            }
         }
+        ResolvedVolumeMode::Software | ResolvedVolumeMode::None => 100,
     };
-    let initial_muted = {
-        let vol_ctrl = VOLUME_CONTROLLER.read();
-        if let Some(ref vc) = *vol_ctrl {
-            vc.get_mute().unwrap_or(false)
-        } else {
-            false
+    let initial_muted = match resolved_mode {
+        ResolvedVolumeMode::Hardware => {
+            let vol_ctrl = VOLUME_CONTROLLER.read();
+            if let Some(ref vc) = *vol_ctrl {
+                vc.get_mute().unwrap_or(false)
+            } else {
+                false
+            }
         }
+        ResolvedVolumeMode::Software | ResolvedVolumeMode::None => false,
     };
 
+    let report_volume = (resolved_mode != ResolvedVolumeMode::None).then_some(initial_volume);
+    let report_muted = (resolved_mode != ResolvedVolumeMode::None).then_some(initial_muted);
     let client_state = Message::ClientState(ClientState {
         player: Some(PlayerState {
             state: PlayerSyncState::Synchronized,
-            volume: Some(initial_volume),
-            muted: Some(initial_muted),
+            volume: report_volume,
+            muted: report_muted,
         }),
     });
     let state_json = serde_json::to_string(&client_state)?;
@@ -464,8 +534,14 @@ async fn run_authenticated_client(
 
     // Spawn playback thread that owns the SyncedPlayer
     let clock_sync_for_thread = Arc::clone(&clock_sync);
+    let use_software_volume = resolved_mode == ResolvedVolumeMode::Software;
     let _playback_handle = thread::spawn(move || {
-        run_playback_thread(player_rx, clock_sync_for_thread, device);
+        run_playback_thread(
+            player_rx,
+            clock_sync_for_thread,
+            device,
+            use_software_volume,
+        );
     });
 
     // Message handling variables
@@ -474,27 +550,32 @@ async fn run_authenticated_client(
     let mut endian_locked: Option<PcmEndian> = None;
     let mut playback_started = false;
 
-    // Volume state (synchronized with hardware volume controller)
-    // Try to get initial volume from hardware
-    let mut current_volume: u8 = {
-        let vol_ctrl = VOLUME_CONTROLLER.read();
-        if let Some(ref vc) = *vol_ctrl {
-            vc.get_volume().unwrap_or(100)
-        } else {
-            100
+    // Volume state (synchronized with hardware volume controller or software gain)
+    let mut current_volume: u8 = match resolved_mode {
+        ResolvedVolumeMode::Hardware => {
+            let vol_ctrl = VOLUME_CONTROLLER.read();
+            if let Some(ref vc) = *vol_ctrl {
+                vc.get_volume().unwrap_or(100)
+            } else {
+                100
+            }
         }
+        ResolvedVolumeMode::Software | ResolvedVolumeMode::None => 100,
     };
-    let mut current_muted: bool = {
-        let vol_ctrl = VOLUME_CONTROLLER.read();
-        if let Some(ref vc) = *vol_ctrl {
-            vc.get_mute().unwrap_or(false)
-        } else {
-            false
+    let mut current_muted: bool = match resolved_mode {
+        ResolvedVolumeMode::Hardware => {
+            let vol_ctrl = VOLUME_CONTROLLER.read();
+            if let Some(ref vc) = *vol_ctrl {
+                vc.get_mute().unwrap_or(false)
+            } else {
+                false
+            }
         }
+        ResolvedVolumeMode::Software | ResolvedVolumeMode::None => false,
     };
 
-    // Log initial volume if hardware control is available
-    {
+    // Log initial volume state
+    if resolved_mode == ResolvedVolumeMode::Hardware {
         let vol_ctrl = VOLUME_CONTROLLER.read();
         if vol_ctrl.is_some() {
             eprintln!(
@@ -626,26 +707,38 @@ async fn run_authenticated_client(
                                                 // Handle server command for player control
                                                 if let Some(payload) = generic.get("payload") {
                                                     if let Some(player_cmd) = payload.get("player") {
-                                                        // Handle volume command via hardware volume control
+                                                        // Handle volume command
                                                         if let Some(volume) = player_cmd.get("volume").and_then(|v| v.as_u64()) {
                                                             let vol = (volume as u8).min(100);
 
-                                                            // Use hardware volume controller if available
-                                                            let volume_result = {
-                                                                let vol_ctrl = VOLUME_CONTROLLER.read();
-                                                                if let Some(ref vc) = *vol_ctrl {
-                                                                    vc.set_volume(vol)
-                                                                } else {
-                                                                    Err("Volume controller not available".to_string())
+                                                            let success = match resolved_mode {
+                                                                ResolvedVolumeMode::Hardware => {
+                                                                    let volume_result = {
+                                                                        let vol_ctrl = VOLUME_CONTROLLER.read();
+                                                                        if let Some(ref vc) = *vol_ctrl {
+                                                                            vc.set_volume(vol)
+                                                                        } else {
+                                                                            Err("Volume controller not available".to_string())
+                                                                        }
+                                                                    };
+                                                                    if let Err(e) = &volume_result {
+                                                                        eprintln!("[Sendspin] Failed to set hardware volume: {}", e);
+                                                                    }
+                                                                    volume_result.is_ok()
                                                                 }
-                                                            }; // Lock is released here
+                                                                ResolvedVolumeMode::Software => {
+                                                                    let _ = player_tx.send(PlayerCommand::SetVolume(vol));
+                                                                    true // Software volume always succeeds (command queued)
+                                                                }
+                                                                ResolvedVolumeMode::None => false,
+                                                            };
 
-                                                            if let Err(e) = volume_result {
-                                                                eprintln!("[Sendspin] Failed to set volume: {}", e);
-                                                            } else {
+                                                            if success {
                                                                 current_volume = vol;
-
-                                                                // Send updated state back to server
+                                                                // Echo state back so the server updates its
+                                                                // controller state. Without this, the server's
+                                                                // view of volume stays stale and the UI slider
+                                                                // resets on the next ServerState broadcast.
                                                                 let state = Message::ClientState(ClientState {
                                                                     player: Some(PlayerState {
                                                                         state: PlayerSyncState::Synchronized,
@@ -659,24 +752,32 @@ async fn run_authenticated_client(
                                                             }
                                                         }
 
-                                                        // Handle mute command via hardware volume control
+                                                        // Handle mute command
                                                         if let Some(mute) = player_cmd.get("mute").and_then(|v| v.as_bool()) {
-                                                            // Use hardware volume controller if available
-                                                            let mute_result = {
-                                                                let vol_ctrl = VOLUME_CONTROLLER.read();
-                                                                if let Some(ref vc) = *vol_ctrl {
-                                                                    vc.set_mute(mute)
-                                                                } else {
-                                                                    Err("Volume controller not available".to_string())
+                                                            let success = match resolved_mode {
+                                                                ResolvedVolumeMode::Hardware => {
+                                                                    let mute_result = {
+                                                                        let vol_ctrl = VOLUME_CONTROLLER.read();
+                                                                        if let Some(ref vc) = *vol_ctrl {
+                                                                            vc.set_mute(mute)
+                                                                        } else {
+                                                                            Err("Volume controller not available".to_string())
+                                                                        }
+                                                                    };
+                                                                    if let Err(e) = &mute_result {
+                                                                        eprintln!("[Sendspin] Failed to set hardware mute: {}", e);
+                                                                    }
+                                                                    mute_result.is_ok()
                                                                 }
-                                                            }; // Lock is released here
+                                                                ResolvedVolumeMode::Software => {
+                                                                    let _ = player_tx.send(PlayerCommand::SetMute(mute));
+                                                                    true
+                                                                }
+                                                                ResolvedVolumeMode::None => false,
+                                                            };
 
-                                                            if let Err(e) = mute_result {
-                                                                eprintln!("[Sendspin] Failed to set mute: {}", e);
-                                                            } else {
+                                                            if success {
                                                                 current_muted = mute;
-
-                                                                // Send updated state back to server
                                                                 let state = Message::ClientState(ClientState {
                                                                     player: Some(PlayerState {
                                                                         state: PlayerSyncState::Synchronized,
@@ -804,8 +905,11 @@ fn run_playback_thread(
     rx: std_mpsc::Receiver<PlayerCommand>,
     clock_sync: Arc<Mutex<ClockSync>>,
     device: Option<cpal::Device>,
+    use_software_volume: bool,
 ) {
     let mut synced_player: Option<SyncedPlayer> = None;
+    let mut last_volume: u8 = 100;
+    let mut last_muted: bool = false;
 
     loop {
         match rx.recv() {
@@ -815,8 +919,19 @@ fn run_playback_thread(
                     player.clear();
                 }
 
-                // Create new SyncedPlayer
-                match SyncedPlayer::new(format, Arc::clone(&clock_sync), device.clone()) {
+                // Create new SyncedPlayer with current volume/mute state
+                let (vol, mute) = if use_software_volume {
+                    (last_volume, last_muted)
+                } else {
+                    (100, false)
+                };
+                match SyncedPlayer::new(
+                    format.clone(),
+                    Arc::clone(&clock_sync),
+                    device.clone(),
+                    vol,
+                    mute,
+                ) {
                     Ok(player) => {
                         synced_player = Some(player);
                     }
@@ -827,13 +942,28 @@ fn run_playback_thread(
             }
             Ok(PlayerCommand::Enqueue(buffer)) => {
                 if let Some(ref player) = synced_player {
-                    // Enqueue buffer directly - volume control is handled via hardware
                     player.enqueue(buffer);
                 }
             }
             Ok(PlayerCommand::Clear) => {
                 if let Some(ref player) = synced_player {
                     player.clear();
+                }
+            }
+            Ok(PlayerCommand::SetVolume(volume)) => {
+                if use_software_volume {
+                    last_volume = volume;
+                    if let Some(ref player) = synced_player {
+                        player.set_volume(volume);
+                    }
+                }
+            }
+            Ok(PlayerCommand::SetMute(muted)) => {
+                if use_software_volume {
+                    last_muted = muted;
+                    if let Some(ref player) = synced_player {
+                        player.set_mute(muted);
+                    }
                 }
             }
             Ok(PlayerCommand::Shutdown) | Err(_) => {
@@ -899,6 +1029,20 @@ pub async fn stop() {
     }
 }
 
+/// Restart the Sendspin client with the existing config.
+/// Used when settings change (e.g., volume control mode, audio device)
+/// to make the new settings take effect immediately.
+/// Does nothing if no client is currently running.
+pub async fn restart() {
+    // Read lock is scoped to this block so it's released before start()
+    // calls stop(), which takes a write lock on SENDSPIN_CLIENT.
+    let config = { SENDSPIN_CLIENT.read().as_ref().map(|c| c.config.clone()) };
+    if let Some(config) = config {
+        log::info!("Restarting Sendspin client to apply new settings");
+        let _ = start(config).await;
+    }
+}
+
 /// Send a playback command (play, pause, stop, next, previous)
 pub fn send_command(command: &str) -> Result<(), String> {
     let client = SENDSPIN_CLIENT.read();
@@ -916,5 +1060,67 @@ pub fn send_command(command: &str) -> Result<(), String> {
         Ok(())
     } else {
         Err("Command channel not available".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::VolumeControlMode;
+
+    #[test]
+    fn resolve_volume_mode_auto_with_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Auto, true),
+            ResolvedVolumeMode::Hardware
+        );
+    }
+
+    #[test]
+    fn resolve_volume_mode_auto_without_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Auto, false),
+            ResolvedVolumeMode::Software
+        );
+    }
+
+    #[test]
+    fn resolve_volume_mode_hardware_with_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Hardware, true),
+            ResolvedVolumeMode::Hardware
+        );
+    }
+
+    #[test]
+    fn resolve_volume_mode_hardware_without_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Hardware, false),
+            ResolvedVolumeMode::None
+        );
+    }
+
+    #[test]
+    fn resolve_volume_mode_software_ignores_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Software, true),
+            ResolvedVolumeMode::Software
+        );
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Software, false),
+            ResolvedVolumeMode::Software
+        );
+    }
+
+    #[test]
+    fn resolve_volume_mode_disabled_ignores_hardware() {
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Disabled, true),
+            ResolvedVolumeMode::None
+        );
+        assert_eq!(
+            resolve_volume_mode(&VolumeControlMode::Disabled, false),
+            ResolvedVolumeMode::None
+        );
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -44,6 +44,19 @@ pub struct Settings {
     // Volume control mode
     #[serde(default)]
     pub volume_control_mode: VolumeControlMode,
+    // Persisted software volume (0-100). Used to restore volume across
+    // reconnects, which happen on every track change. Only written in
+    // software volume mode; hardware volume uses the OS as source of truth.
+    #[serde(default = "default_software_volume")]
+    pub software_volume: u8,
+    // Persisted mute state. Shared across hardware and software modes
+    // since mute is lost on every reconnect (new connection per track).
+    #[serde(default)]
+    pub muted: bool,
+}
+
+fn default_software_volume() -> u8 {
+    100
 }
 
 fn default_player_name() -> String {
@@ -79,6 +92,8 @@ impl Default for Settings {
             audio_device_id: None,
             sync_delay_ms: 0,
             volume_control_mode: VolumeControlMode::default(),
+            software_volume: default_software_volume(),
+            muted: false,
         }
     }
 }
@@ -96,6 +111,8 @@ static SETTINGS: RwLock<Settings> = RwLock::new(Settings {
     audio_device_id: None,
     sync_delay_ms: 0,
     volume_control_mode: VolumeControlMode::Auto,
+    software_volume: 100,
+    muted: false,
 });
 
 fn get_settings_path() -> Option<PathBuf> {
@@ -247,6 +264,40 @@ mod tests {
     #[test]
     fn volume_control_mode_default_is_auto() {
         assert_eq!(VolumeControlMode::default(), VolumeControlMode::Auto);
+    }
+
+    #[test]
+    fn software_volume_default_is_100() {
+        let settings = Settings::default();
+        assert_eq!(settings.software_volume, 100);
+    }
+
+    #[test]
+    fn muted_default_is_false() {
+        let settings = Settings::default();
+        assert!(!settings.muted);
+    }
+
+    #[test]
+    fn software_volume_serde_roundtrip() {
+        let settings = Settings {
+            software_volume: 42,
+            muted: true,
+            ..Settings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let deserialized: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.software_volume, 42);
+        assert!(deserialized.muted);
+    }
+
+    #[test]
+    fn software_volume_missing_from_json_uses_default() {
+        // Simulate loading settings from an older version without these fields
+        let json = r#"{"discord_rpc_enabled":true,"start_minimized":false,"autostart":false,"sendspin_enabled":true,"sendspin_player_name":"test","sync_delay_ms":0,"volume_control_mode":"auto"}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.software_volume, 100);
+        assert!(!settings.muted);
     }
 
     #[test]


### PR DESCRIPTION
Replace the app-side SoftwareGainState (which applied gain before enqueue, causing ~2s latency) with sendspin's new GainControl that applies gain in the cpal output callback. Volume and mute changes now take effect instantly.

- Add volume control mode setting (auto/hardware/software/disabled)
- Add volume control UI to settings page
- Remove software_gain.rs (now handled by sendspin)
- Simplify playback thread: no more buffer mutation before enqueue

Depends on: https://github.com/Sendspin/sendspin-rs/pull/10

NOTE: I tested this locally against the sendspin-rs in that PR but until that PR is merged, this code won't build. And even after, I'll need to update the Cargo.lock. So I'm marking this as DRAFT for now. But testing should be as easy as checking out the branch in the sendspin-rs PR, pointing the src-tauri/Cargo.toml to the local copy and building.