### PR TITLE
fix: add auto-reconnect with backoff to Sendspin client

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -273,6 +273,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1063,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
@@ -1066,6 +1086,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1212,7 +1243,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.8",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2655,6 +2686,7 @@ dependencies = [
  "souvlaki",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -4847,6 +4879,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6566,6 +6612,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/src/sendspin/mod.rs
+++ b/src-tauri/src/sendspin/mod.rs
@@ -33,6 +33,22 @@ use sendspin::protocol::messages::{
 };
 use sendspin::sync::ClockSync;
 
+/// Simple jitter: returns a pseudo-random value in `0..max_ms/4` using the
+/// current timestamp as entropy. No external crate needed.
+fn rand_jitter_ms(max_ms: u64) -> u64 {
+    let range = max_ms / 4;
+    if range == 0 {
+        return 0;
+    }
+    let nanos = u64::from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos(),
+    );
+    nanos % range
+}
+
 /// Commands sent to the playback thread
 enum PlayerCommand {
     /// Create a new `SyncedPlayer` with the given format
@@ -143,6 +159,7 @@ pub enum ConnectionStatus {
     Disconnected,
     Connecting,
     Connected,
+    Reconnecting,
     Error(String),
 }
 
@@ -217,27 +234,80 @@ pub async fn start(config: SendspinConfig) -> Result<String, String> {
 
     set_enabled(true);
 
-    // Create shutdown channel
-    let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>(1);
-    {
-        let mut tx = SHUTDOWN_TX.write();
-        *tx = Some(shutdown_tx);
-    }
-
-    // Create command channel for playback control
-    let (command_tx, command_rx) = mpsc::channel::<String>(32);
-    {
-        let mut tx = COMMAND_TX.write();
-        *tx = Some(command_tx);
-    }
-
-    // Spawn the client task and store the handle
+    // Spawn the client task with reconnection loop
     let config_clone = config.clone();
     let player_id_clone = player_id.clone();
     let task_handle = tokio::spawn(async move {
-        if let Err(e) = run_client(config_clone, player_id_clone, shutdown_rx, command_rx).await {
-            eprintln!("[Sendspin] Client error: {}", e);
-            update_status(ConnectionStatus::Error(e.to_string()));
+        const MAX_BACKOFF: Duration = Duration::from_secs(30);
+        let mut backoff = Duration::from_secs(1);
+
+        loop {
+            // Create fresh channels for this connection attempt
+            let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>(1);
+            let (command_tx, command_rx) = mpsc::channel::<String>(32);
+
+            // Update globals so stop()/send_command() reach the current connection
+            {
+                *SHUTDOWN_TX.write() = Some(shutdown_tx);
+            }
+            {
+                *COMMAND_TX.write() = Some(command_tx);
+            }
+
+            let connected_at = Instant::now();
+
+            let result = run_client(
+                config_clone.clone(),
+                player_id_clone.clone(),
+                shutdown_rx,
+                command_rx,
+            )
+            .await;
+
+            // If stop() was called, exit cleanly
+            if !is_enabled() {
+                break;
+            }
+
+            // Reset backoff if the connection was alive for >10 seconds
+            // (meaning it was a real session, not an immediate failure)
+            if connected_at.elapsed() > Duration::from_secs(10) {
+                backoff = Duration::from_secs(1);
+            }
+
+            match result {
+                Ok(()) => {
+                    eprintln!("[Sendspin] Disconnected, reconnecting in {:?}...", backoff);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[Sendspin] Client error: {}, reconnecting in {:?}...",
+                        e, backoff
+                    );
+                }
+            }
+
+            update_status(ConnectionStatus::Reconnecting);
+
+            // Sleep in small increments so stop() can interrupt quickly
+            let deadline = Instant::now() + backoff;
+            while Instant::now() < deadline {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                if !is_enabled() {
+                    break;
+                }
+            }
+            if !is_enabled() {
+                break;
+            }
+
+            // Exponential backoff with jitter. The cap is intentionally soft —
+            // jitter is added after clamping, so actual delay can exceed MAX_BACKOFF
+            // by up to ~25%. This is fine; the jitter exists to spread out reconnects.
+            let jitter = Duration::from_millis(rand_jitter_ms(backoff.as_millis() as u64));
+            backoff = (backoff * 2).min(MAX_BACKOFF) + jitter;
+
+            update_status(ConnectionStatus::Connecting);
         }
     });
 


### PR DESCRIPTION
I noticed that a good chunk of the time when restarting the MA server, that the desktop app's local sendspin client wouldn't cleanly reconnect, so I added some retry logic for our connection. I considered putting it in the sendspin-rs library but we need to authenticate with HA/ourselves and I didn't want to add that complexity to the library (at least not without some discussion, and frankly I'm not convinced it's the right place for that. Though I could be).

When the server restarts, run_client() now retries in a loop with exponential backoff (1s → 30s cap) and jitter. Backoff resets after a session lasts >10s. The loop exits cleanly when stop() is called.

Adds ConnectionStatus::Reconnecting so the frontend can distinguish reconnection attempts from permanent disconnection.

Also updates Cargo.lock to include resolved dependencies for tauri-plugin-autostart, which were missing from main.