### PR TITLE
Seed initial volume/mute state to prevent spurious logged notifications

### DIFF
--- a/src-tauri/src/sendspin/volume_control/macos.rs
+++ b/src-tauri/src/sendspin/volume_control/macos.rs
@@ -258,13 +258,20 @@ impl VolumeControlImpl for MacOSVolumeControl {
         let last_self_change = Arc::clone(&self.last_self_change);
         let stop_flag = Arc::clone(&self.stop_flag);
 
+        // Read initial volume/mute so the polling thread doesn't fire a
+        // spurious "changed" notification on its first tick.
+        let initial_values = match (self.get_volume(), self.get_mute()) {
+            (Ok(v), Ok(m)) => Some((v, m)),
+            _ => None,
+        };
+
         let polling_thread = std::thread::spawn(move || {
             use std::time::Duration;
 
             const POLL_INTERVAL: Duration = Duration::from_secs(2);
             const SELF_CHANGE_GRACE_PERIOD: u64 = 1000; // milliseconds
 
-            let mut last_values: Option<(u8, bool)> = None;
+            let mut last_values: Option<(u8, bool)> = initial_values;
 
             loop {
                 std::thread::sleep(POLL_INTERVAL);

--- a/src-tauri/src/sendspin/volume_control/windows.rs
+++ b/src-tauri/src/sendspin/volume_control/windows.rs
@@ -175,6 +175,13 @@ impl VolumeControlImpl for WindowsVolumeControl {
         let last_self_change = Arc::clone(&self.last_self_change);
         let stop_flag = Arc::clone(&self.stop_flag);
 
+        // Read initial volume/mute so the polling thread doesn't fire a
+        // spurious "changed" notification on its first tick.
+        let initial_values = match (self.get_volume(), self.get_mute()) {
+            (Ok(v), Ok(m)) => Some((v, m)),
+            _ => None,
+        };
+
         let polling_thread = std::thread::spawn(move || {
             use std::time::Duration;
 
@@ -191,7 +198,7 @@ impl VolumeControlImpl for WindowsVolumeControl {
             const POLL_INTERVAL: Duration = Duration::from_secs(2);
             const SELF_CHANGE_GRACE_PERIOD: u64 = 1000; // milliseconds
 
-            let mut last_values: Option<(u8, bool)> = None;
+            let mut last_values: Option<(u8, bool)> = initial_values;
 
             loop {
                 std::thread::sleep(POLL_INTERVAL);


### PR DESCRIPTION
The volume polling thread started with `last_values = None`, which caused it to always fire an OS volume changed notification on its first tick (because `None != Some((current_vol, current_mute))`). This fix reads the current volume and mute state before spawning the polling thread and seeds `last_values` with it, so only actual changes trigger notifications.

Applies to macOS (CoreAudio) and Windows (WASAPI). Linux is unaffected as it uses PulseAudio's native event subscription instead of polling.

Previously:
```
[VolumeControl] macOS CoreAudio volume control initialized successfully
[Sendspin] Volume control: mode=Hardware, hardware_available=true, resolved=Hardware
[VolumeControl] macOS volume polling enabled (2s interval)
[Sendspin] Initial hardware volume: 32%, muted: false
[Sendspin] OS volume changed: 32%, muted: false
```

Now:
```
[VolumeControl] macOS CoreAudio volume control initialized successfully
[Sendspin] Volume control: mode=Hardware, hardware_available=true, resolved=Hardware
[VolumeControl] macOS volume polling enabled (2s interval)
[Sendspin] Initial hardware volume: 32%, muted: false
```