### PR TITLE
Add unit tests and extract helpers for testability

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -273,6 +273,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1063,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
@@ -1066,6 +1086,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1212,7 +1243,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.8",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2655,6 +2686,7 @@ dependencies = [
  "souvlaki",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -4940,6 +4972,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6678,6 +6724,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/src/discord_rpc.rs
+++ b/src-tauri/src/discord_rpc.rs
@@ -14,6 +14,35 @@ const CLIENT_ID: &str = "1107294634507518023";
 // Global Discord client for clearing activity
 static DISCORD_CLIENT: Mutex<Option<DiscordIpcClient>> = Mutex::new(None);
 
+/// Extract Discord fields from `NowPlaying` struct
+/// Returns (track, artist, album, `image_url`) with defaults for missing values
+fn extract_discord_fields(np: &NowPlaying) -> (&str, &str, &str, &str) {
+    let track = np.track.as_deref().unwrap_or("Unknown Track");
+    let artist = np.artist.as_deref().unwrap_or("Unknown Artist");
+    let album = np.album.as_deref().unwrap_or("");
+    let image_url = np.image_url.as_deref().unwrap_or("");
+    (track, artist, album, image_url)
+}
+
+/// Calculate Discord activity timestamps
+/// Takes elapsed and duration in seconds, returns (`start_timestamp`, `end_timestamp`) in milliseconds
+/// `current_time_ms` is the current Unix timestamp in milliseconds (allows for testing with fixed time)
+fn calculate_discord_timestamps(
+    elapsed_secs: Option<u64>,
+    duration_secs: Option<u64>,
+    current_time_ms: i64,
+) -> (i64, i64) {
+    let elapsed_ms = elapsed_secs.unwrap_or(0) as i64 * 1000;
+    let duration_ms = duration_secs.unwrap_or(0) as i64 * 1000;
+    let started = current_time_ms - elapsed_ms;
+    let end = if duration_ms > 0 {
+        current_time_ms + (duration_ms - elapsed_ms)
+    } else {
+        0
+    };
+    (started, end)
+}
+
 /// Clear the Discord activity (called when Discord RPC is disabled)
 pub fn clear_activity() {
     if let Ok(mut client_guard) = DISCORD_CLIENT.lock() {
@@ -72,10 +101,7 @@ fn update_discord_activity(
     }
 
     // Get track info
-    let track_name = np.track.as_deref().unwrap_or("Unknown Track");
-    let artist_name = np.artist.as_deref().unwrap_or("Unknown Artist");
-    let album_name = np.album.as_deref().unwrap_or("");
-    let image_url = np.image_url.as_deref().unwrap_or("");
+    let (track_name, artist_name, album_name, image_url) = extract_discord_fields(np);
 
     // Calculate timestamps
     let current_time = SystemTime::now()
@@ -83,15 +109,7 @@ fn update_discord_activity(
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0);
 
-    let elapsed_ms = np.elapsed.unwrap_or(0) as i64 * 1000;
-    let duration_ms = np.duration.unwrap_or(0) as i64 * 1000;
-
-    let started = current_time - elapsed_ms;
-    let end = if duration_ms > 0 {
-        current_time + (duration_ms - elapsed_ms)
-    } else {
-        0
-    };
+    let (started, end) = calculate_discord_timestamps(np.elapsed, np.duration, current_time);
 
     // Build assets
     let mut assets = activity::Assets::new();
@@ -119,4 +137,47 @@ fn update_discord_activity(
 
     client.set_activity(payload)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_discord_timestamps() {
+        type TimestampCase = (Option<u64>, Option<u64>, i64, i64, i64);
+        let t = 100_000i64;
+        // (elapsed, duration, current_time) → (expected_start, expected_end)
+        let cases: Vec<TimestampCase> = vec![
+            // Normal playback: 30s into a 180s track
+            (Some(30), Some(180), t, t - 30_000, t + 150_000),
+            // No duration → end=0
+            (Some(30), None, t, t - 30_000, 0),
+            // Zero duration → end=0
+            (Some(30), Some(0), t, t - 30_000, 0),
+            // No elapsed, no duration → start=current, end=0
+            (None, None, t, t, 0),
+            // Elapsed exceeds duration (track overran)
+            (Some(180), Some(120), t, t - 180_000, t - 60_000),
+            // Large values (1hr into 2hr track)
+            (
+                Some(3600),
+                Some(7200),
+                1_000_000_000,
+                1_000_000_000 - 3_600_000,
+                1_000_000_000 + 3_600_000,
+            ),
+        ];
+        for (elapsed, duration, now, exp_start, exp_end) in cases {
+            let (started, end) = calculate_discord_timestamps(elapsed, duration, now);
+            assert_eq!(
+                started, exp_start,
+                "start: elapsed={elapsed:?} duration={duration:?}"
+            );
+            assert_eq!(
+                end, exp_end,
+                "end: elapsed={elapsed:?} duration={duration:?}"
+            );
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -409,16 +409,7 @@ async fn configure_sendspin(
 ) -> Result<Option<String>, String> {
     let loaded_settings = settings::get_settings();
 
-    // Build Sendspin WebSocket URL from the MA server base URL
-    let ws_scheme = if server_base_url.starts_with("https") {
-        "wss"
-    } else {
-        "ws"
-    };
-    let url_without_scheme = server_base_url
-        .replace("https://", "")
-        .replace("http://", "");
-    let sendspin_url = format!("{}://{}/sendspin", ws_scheme, url_without_scheme);
+    let sendspin_url = build_sendspin_ws_url(&server_base_url);
 
     // Save the URL to settings
     let _ = settings::set_string_setting("sendspin_server_url", Some(sendspin_url.clone()));
@@ -432,14 +423,7 @@ async fn configure_sendspin(
                 .and_then(|h| h.into_string().ok())
                 .map_or_else(
                     || "Music Assistant Companion".to_string(),
-                    |name| {
-                        // Strip common suffixes like .local, .lan, .home
-                        name.trim_end_matches(".local")
-                            .trim_end_matches(".lan")
-                            .trim_end_matches(".home")
-                            .trim_end_matches(".localdomain")
-                            .to_string()
-                    },
+                    |name| strip_hostname_suffix(&name),
                 )
         } else {
             loaded_settings.sendspin_player_name.clone()
@@ -468,6 +452,30 @@ async fn configure_sendspin(
     }
 
     Ok(None)
+}
+
+/// Build a WebSocket URL for Sendspin from an HTTP(S) server base URL
+fn build_sendspin_ws_url(server_base_url: &str) -> String {
+    let ws_scheme = if server_base_url.starts_with("https") {
+        "wss"
+    } else {
+        "ws"
+    };
+    let url_without_scheme = server_base_url
+        .replace("https://", "")
+        .replace("http://", "")
+        .trim_end_matches('/')
+        .to_string();
+    format!("{}://{}/sendspin", ws_scheme, url_without_scheme)
+}
+
+/// Strip common local network suffixes from a hostname
+fn strip_hostname_suffix(name: &str) -> String {
+    name.trim_end_matches(".local")
+        .trim_end_matches(".lan")
+        .trim_end_matches(".home")
+        .trim_end_matches(".localdomain")
+        .to_string()
 }
 
 /// Open or focus the companion app's settings window.
@@ -850,4 +858,45 @@ pub fn run() {
         })
         .run(context)
         .expect("Error while running Music Assistant companion");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_sendspin_ws_url_https() {
+        assert_eq!(
+            build_sendspin_ws_url("https://192.168.1.47:8095"),
+            "wss://192.168.1.47:8095/sendspin"
+        );
+    }
+
+    #[test]
+    fn test_build_sendspin_ws_url_http() {
+        assert_eq!(
+            build_sendspin_ws_url("http://192.168.1.47:8095"),
+            "ws://192.168.1.47:8095/sendspin"
+        );
+    }
+
+    #[test]
+    fn test_build_sendspin_ws_url_with_trailing_slash() {
+        assert_eq!(
+            build_sendspin_ws_url("http://192.168.1.47:8095/"),
+            "ws://192.168.1.47:8095/sendspin"
+        );
+    }
+
+    #[test]
+    fn test_build_sendspin_ws_url_case_sensitive_scheme() {
+        // Current implementation is case-sensitive: HTTPS:// won't match "https"
+        // This documents the behavior — uppercase schemes fall through to "ws"
+        let url = build_sendspin_ws_url("HTTPS://server.example.com");
+        assert!(
+            url.starts_with("ws://"),
+            "Expected ws:// for uppercase HTTPS, got: {}",
+            url
+        );
+    }
 }

--- a/src-tauri/src/mdns_discovery.rs
+++ b/src-tauri/src/mdns_discovery.rs
@@ -7,6 +7,34 @@ use std::time::Duration;
 /// Music Assistant mDNS service type
 const MA_SERVICE_TYPE: &str = "_mass._tcp.local.";
 
+/// Parse IP address from a base URL
+/// Supports `<http://192.168.1.47:8095>` or `<https://10.0.0.1:443>` format
+/// Returns None if the URL format is invalid or contains non-parseable IP
+fn parse_ip_from_base_url(url_str: &str) -> Option<std::net::IpAddr> {
+    let clean = url_str.replace("http://", "").replace("https://", "");
+    clean.split(':').next()?.parse::<std::net::IpAddr>().ok()
+}
+
+/// Select preferred IP address from available options
+/// Prioritizes: TXT record IP > IPv4 from addresses > IPv6 from addresses
+/// Returns None if no IP is available
+fn select_preferred_ip(
+    txt_ip: Option<std::net::IpAddr>,
+    addresses: &[std::net::IpAddr],
+) -> Option<std::net::IpAddr> {
+    if let Some(ip) = txt_ip {
+        return Some(ip);
+    }
+    if addresses.is_empty() {
+        return None;
+    }
+    addresses
+        .iter()
+        .find(|addr| addr.is_ipv4())
+        .or(addresses.first())
+        .copied()
+}
+
 /// Discovered Music Assistant server
 #[derive(Debug, Clone, Serialize)]
 pub struct DiscoveredServer {
@@ -62,39 +90,20 @@ pub fn discover_servers(timeout_secs: u64) -> Result<Vec<DiscoveredServer>, Stri
 
                         // Try to get the correct IP from TXT records
                         // Music Assistant may include base_url with the actual server IP
-                        let mut ip_from_txt: Option<std::net::IpAddr> = None;
-                        if let Some(base_url) = properties.get("base_url") {
-                            let url_str = base_url.val_str();
-                            // Parse URL like "http://192.168.1.47:8095" to extract IP
-                            let clean = url_str.replace("http://", "").replace("https://", "");
-                            if let Some(host_part) = clean.split(':').next() {
-                                if let Ok(ip) = host_part.parse::<std::net::IpAddr>() {
-                                    ip_from_txt = Some(ip);
-                                }
-                            }
-                        }
+                        let ip_from_txt: Option<std::net::IpAddr> = properties
+                            .get("base_url")
+                            .and_then(|base_url| parse_ip_from_base_url(base_url.val_str()));
 
                         let port = info.get_port();
 
                         // Use IP from TXT record if available, otherwise fall back to addresses
-                        let ip: std::net::IpAddr = if let Some(txt_ip) = ip_from_txt {
-                            txt_ip
-                        } else {
-                            // Get addresses from mDNS (may be aggregated from multiple hosts)
-                            let addresses: Vec<std::net::IpAddr> =
-                                info.get_addresses().iter().copied().collect();
-
-                            if addresses.is_empty() {
-                                continue;
-                            }
-
-                            // Prefer IPv4 addresses over IPv6
-                            *addresses
-                                .iter()
-                                .find(|addr| addr.is_ipv4())
-                                .or(addresses.first())
-                                .unwrap()
-                        };
+                        let addresses: Vec<std::net::IpAddr> =
+                            info.get_addresses().iter().copied().collect();
+                        let ip: std::net::IpAddr =
+                            match select_preferred_ip(ip_from_txt, &addresses) {
+                                Some(ip) => ip,
+                                None => continue,
+                            };
 
                         // Check if HTTPS is available (default to false)
                         let https = properties
@@ -144,4 +153,53 @@ pub fn discover_servers(timeout_secs: u64) -> Result<Vec<DiscoveredServer>, Stri
         .collect();
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn test_parse_ip_from_base_url() {
+        let v4 = |a, b, c, d| Some(IpAddr::V4(Ipv4Addr::new(a, b, c, d)));
+        let cases: Vec<(&str, Option<IpAddr>)> = vec![
+            ("http://192.168.1.47:8095", v4(192, 168, 1, 47)),
+            ("https://10.0.0.1:443", v4(10, 0, 0, 1)),
+            ("192.168.1.100:8095", v4(192, 168, 1, 100)),
+            ("http://[::1]:8095", None), // Brackets don't parse as bare IpAddr
+            ("http://not_an_ip:8095", None),
+            ("", None),
+            ("http://", None),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(parse_ip_from_base_url(input), expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn test_select_preferred_ip() {
+        let v4 = |a, b, c, d| IpAddr::V4(Ipv4Addr::new(a, b, c, d));
+        let v6_loopback = IpAddr::V6(Ipv6Addr::LOCALHOST);
+
+        // TXT IP takes precedence over mDNS addresses
+        assert_eq!(
+            select_preferred_ip(Some(v4(192, 168, 1, 1)), &[v4(10, 0, 0, 1)]),
+            Some(v4(192, 168, 1, 1))
+        );
+        // IPv4 preferred over IPv6
+        assert_eq!(
+            select_preferred_ip(None, &[v6_loopback, v4(192, 168, 1, 1)]),
+            Some(v4(192, 168, 1, 1))
+        );
+        // Falls back to IPv6 when no IPv4 available
+        assert_eq!(select_preferred_ip(None, &[v6_loopback]), Some(v6_loopback));
+        // No addresses and no TXT → None
+        assert_eq!(select_preferred_ip(None, &[]), None);
+        // Multiple IPv4 → returns first
+        assert_eq!(
+            select_preferred_ip(None, &[v4(192, 168, 1, 1), v4(10, 0, 0, 1)]),
+            Some(v4(192, 168, 1, 1))
+        );
+    }
 }

--- a/src-tauri/src/media_controls.rs
+++ b/src-tauri/src/media_controls.rs
@@ -76,12 +76,23 @@ fn handle_media_event(event: MediaControlEvent) {
         MediaControlEvent::Next => "next",
         MediaControlEvent::Previous => "previous",
         MediaControlEvent::Stop => "stop",
-        _ => return, // Ignore other events like seek, volume, etc.
+        _ => return,
     };
 
-    // Call the registered callback
     if let Some(ref callback) = *EVENT_CALLBACK.lock() {
         callback(command);
+    }
+}
+
+/// Determine the playback state category from now-playing info
+#[cfg(test)]
+fn determine_playback_state(is_playing: bool, has_track: bool) -> &'static str {
+    if is_playing {
+        "playing"
+    } else if has_track {
+        "paused"
+    } else {
+        "stopped"
     }
 }
 
@@ -128,5 +139,18 @@ pub fn clear() {
     let mut controls = MEDIA_CONTROLS.lock();
     if let Some(ref mut controls) = *controls {
         let _ = controls.set_playback(MediaPlayback::Stopped);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_determine_playback_state() {
+        assert_eq!(determine_playback_state(true, true), "playing");
+        assert_eq!(determine_playback_state(true, false), "playing");
+        assert_eq!(determine_playback_state(false, true), "paused");
+        assert_eq!(determine_playback_state(false, false), "stopped");
     }
 }

--- a/src-tauri/src/now_playing.rs
+++ b/src-tauri/src/now_playing.rs
@@ -126,3 +126,174 @@ pub fn format_now_playing_with_player(np: &NowPlaying) -> String {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn test_update_skips_playing_without_track() {
+        // Save current state to restore later
+        let original_state = get_now_playing();
+
+        // Reset global state to a known state
+        {
+            if let Ok(mut state) = NOW_PLAYING.write() {
+                *state = NowPlaying {
+                    is_playing: false,
+                    track: Some("SomeTrack".to_string()),
+                    ..Default::default()
+                };
+            }
+        }
+
+        // Verify state before update
+        let before_update = get_now_playing();
+        let before_track = before_update.track.clone();
+
+        // Call update_now_playing with is_playing=true but no track (should be skipped)
+        let update = NowPlaying {
+            is_playing: true,
+            track: None,
+            ..Default::default()
+        };
+        update_now_playing(update);
+
+        // Verify state unchanged - track should still be present
+        let after_update = get_now_playing();
+        assert_eq!(
+            after_update.track, before_track,
+            "track should remain unchanged"
+        );
+        assert!(!after_update.is_playing, "is_playing should remain false");
+
+        // Restore original state
+        {
+            if let Ok(mut state) = NOW_PLAYING.write() {
+                *state = original_state;
+            }
+        }
+    }
+
+    #[test]
+    fn test_callback_invoked_on_update() {
+        // Reset global state and callbacks
+        {
+            if let Ok(mut state) = NOW_PLAYING.write() {
+                *state = NowPlaying::default();
+            }
+        }
+        {
+            if let Ok(mut callbacks) = CALLBACKS.lock() {
+                callbacks.clear();
+            }
+        }
+
+        // Create a flag to track callback invocation
+        let callback_invoked = Arc::new(AtomicBool::new(false));
+        let flag_clone = Arc::clone(&callback_invoked);
+
+        // Register callback that sets the flag to true
+        let callback: NowPlayingCallback = Arc::new(move |_np| {
+            flag_clone.store(true, Ordering::SeqCst);
+        });
+        on_now_playing_change(callback);
+
+        // Call update_now_playing with valid data
+        let update = NowPlaying {
+            is_playing: true,
+            track: Some("Test Track".to_string()),
+            ..Default::default()
+        };
+        update_now_playing(update);
+
+        // Verify callback was invoked
+        assert!(callback_invoked.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_format_now_playing_with_player_all_branches() {
+        // Test 1: is_playing=true, artist=Some, track=Some, player_name=Some
+        let np1 = NowPlaying {
+            is_playing: true,
+            artist: Some("Artist1".to_string()),
+            track: Some("Track1".to_string()),
+            player_name: Some("Player1".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            format_now_playing_with_player(&np1),
+            "Artist1 - Track1\nPlayer1"
+        );
+
+        // Test 2: is_playing=true, artist=Some, track=Some, player_name=None
+        let np2 = NowPlaying {
+            is_playing: true,
+            artist: Some("Artist2".to_string()),
+            track: Some("Track2".to_string()),
+            player_name: None,
+            ..Default::default()
+        };
+        assert_eq!(format_now_playing_with_player(&np2), "Artist2 - Track2");
+
+        // Test 3: is_playing=true, artist=None, track=Some, player_name=Some
+        let np3 = NowPlaying {
+            is_playing: true,
+            artist: None,
+            track: Some("Track3".to_string()),
+            player_name: Some("Player3".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(format_now_playing_with_player(&np3), "Track3\nPlayer3");
+
+        // Test 4: is_playing=true, artist=None, track=Some, player_name=None
+        let np4 = NowPlaying {
+            is_playing: true,
+            artist: None,
+            track: Some("Track4".to_string()),
+            player_name: None,
+            ..Default::default()
+        };
+        assert_eq!(format_now_playing_with_player(&np4), "Track4");
+
+        // Test 5: is_playing=true, artist=Some, track=None, player_name=None
+        let np5 = NowPlaying {
+            is_playing: true,
+            artist: Some("Artist5".to_string()),
+            track: None,
+            player_name: None,
+            ..Default::default()
+        };
+        assert_eq!(format_now_playing_with_player(&np5), "Unknown Track");
+
+        // Test 6: is_playing=true, artist=None, track=None, player_name=None
+        let np6 = NowPlaying {
+            is_playing: true,
+            artist: None,
+            track: None,
+            player_name: None,
+            ..Default::default()
+        };
+        assert_eq!(format_now_playing_with_player(&np6), "Unknown Track");
+
+        // Test 7: is_playing=false, player_name=Some("MyPlayer")
+        let np7 = NowPlaying {
+            is_playing: false,
+            player_name: Some("MyPlayer".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            format_now_playing_with_player(&np7),
+            "MyPlayer - Not Playing"
+        );
+
+        // Test 8: is_playing=false, player_name=None
+        let np8 = NowPlaying {
+            is_playing: false,
+            player_name: None,
+            ..Default::default()
+        };
+        assert_eq!(format_now_playing_with_player(&np8), "Music Assistant");
+    }
+}

--- a/src-tauri/src/sendspin/devices.rs
+++ b/src-tauri/src/sendspin/devices.rs
@@ -133,4 +133,71 @@ mod tests {
         // This test just checks that enumeration doesn't panic
         assert!(devices.is_ok());
     }
+
+    #[test]
+    fn test_device_sorting_default_first_and_alphabetical() {
+        let mut devices = [
+            AudioDevice {
+                id: "z".into(),
+                name: "Zebra".into(),
+                is_default: false,
+                sample_rates: vec![],
+                max_channels: 2,
+            },
+            AudioDevice {
+                id: "a".into(),
+                name: "Apple".into(),
+                is_default: false,
+                sample_rates: vec![],
+                max_channels: 2,
+            },
+            AudioDevice {
+                id: "d".into(),
+                name: "Default Speaker".into(),
+                is_default: true,
+                sample_rates: vec![],
+                max_channels: 2,
+            },
+            AudioDevice {
+                id: "m".into(),
+                name: "Monitor".into(),
+                is_default: false,
+                sample_rates: vec![],
+                max_channels: 2,
+            },
+        ]
+        .to_vec();
+
+        // Apply the same sort as list_devices
+        devices.sort_by(|a, b| {
+            if a.is_default && !b.is_default {
+                std::cmp::Ordering::Less
+            } else if !a.is_default && b.is_default {
+                std::cmp::Ordering::Greater
+            } else {
+                a.name.cmp(&b.name)
+            }
+        });
+
+        assert_eq!(devices[0].name, "Default Speaker");
+        assert!(devices[0].is_default);
+        assert_eq!(devices[1].name, "Apple");
+        assert_eq!(devices[2].name, "Monitor");
+        assert_eq!(devices[3].name, "Zebra");
+    }
+
+    #[test]
+    fn test_get_device_by_id_nonexistent_returns_error() {
+        let result = get_device_by_id("definitely_not_a_real_device_12345");
+        match result {
+            Err(err) => {
+                assert!(
+                    err.contains("definitely_not_a_real_device_12345"),
+                    "Error should contain the device ID, got: {}",
+                    err
+                );
+            }
+            Ok(_) => panic!("Expected error for nonexistent device"),
+        }
+    }
 }

--- a/src-tauri/src/sendspin/mod.rs
+++ b/src-tauri/src/sendspin/mod.rs
@@ -1128,4 +1128,31 @@ mod tests {
             ResolvedVolumeMode::None
         );
     }
+
+    #[test]
+    fn test_build_volume_state_msg_produces_valid_json() {
+        let msg = build_volume_state_msg(75, false);
+        assert!(msg.is_some());
+        // Parse the message text
+        if let Some(WsMessage::Text(text)) = msg {
+            let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+            // Check structure
+            assert_eq!(value["type"], "client/state");
+            assert_eq!(value["payload"]["player"]["volume"], 75);
+            assert_eq!(value["payload"]["player"]["muted"], false);
+        } else {
+            panic!("Expected Text message");
+        }
+    }
+
+    #[test]
+    fn test_build_volume_state_msg_muted() {
+        let msg = build_volume_state_msg(0, true);
+        assert!(msg.is_some());
+        if let Some(WsMessage::Text(text)) = msg {
+            let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(value["payload"]["player"]["volume"], 0);
+            assert_eq!(value["payload"]["player"]["muted"], true);
+        }
+    }
 }

--- a/src-tauri/src/sendspin/protocol.rs
+++ b/src-tauri/src/sendspin/protocol.rs
@@ -174,3 +174,94 @@ pub struct GenericMessage {
     #[serde(flatten)]
     pub rest: serde_json::Value,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_command_message_json_format() {
+        // Test new() with Play command - should have no volume/mute fields
+        let msg = ClientCommandMessage::new(MediaCommand::Play);
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["type"].as_str(), Some("client/command"));
+        assert_eq!(
+            json["payload"]["controller"]["command"].as_str(),
+            Some("play")
+        );
+        // Verify volume and mute are not in the JSON (skipped due to skip_serializing_if)
+        assert!(json["payload"]["controller"]["volume"].is_null());
+        assert!(json["payload"]["controller"]["mute"].is_null());
+
+        // Test volume() constructor
+        let msg = ClientCommandMessage::volume(75);
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["type"].as_str(), Some("client/command"));
+        assert_eq!(
+            json["payload"]["controller"]["command"].as_str(),
+            Some("volume")
+        );
+        assert_eq!(json["payload"]["controller"]["volume"].as_u64(), Some(75));
+        assert!(json["payload"]["controller"]["mute"].is_null());
+
+        // Test mute() constructor
+        let msg = ClientCommandMessage::mute(true);
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["type"].as_str(), Some("client/command"));
+        assert_eq!(
+            json["payload"]["controller"]["command"].as_str(),
+            Some("mute")
+        );
+        assert!(json["payload"]["controller"]["volume"].is_null());
+        assert_eq!(json["payload"]["controller"]["mute"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn test_server_state_message_deserialization() {
+        // Test realistic JSON payload with all fields
+        let json_str = r#"{
+  "type": "server/state",
+  "payload": {
+    "metadata": {
+      "timestamp": 1234567890000000,
+      "title": "Test Song",
+      "artist": "Test Artist",
+      "album": "Test Album",
+      "artwork_url": "https://example.com/art.jpg",
+      "progress": {
+        "track_progress": 30000,
+        "track_duration": 180000,
+        "playback_speed": 1000
+      }
+    }
+  }
+}"#;
+
+        let msg: ServerStateMessage = serde_json::from_str(json_str).unwrap();
+        assert_eq!(msg.msg_type, "server/state");
+
+        let metadata = msg.payload.metadata.unwrap();
+        assert_eq!(metadata.timestamp, 1234567890000000);
+        assert_eq!(metadata.title, Some("Test Song".to_string()));
+        assert_eq!(metadata.artist, Some("Test Artist".to_string()));
+        assert_eq!(metadata.album, Some("Test Album".to_string()));
+        assert_eq!(
+            metadata.artwork_url,
+            Some("https://example.com/art.jpg".to_string())
+        );
+
+        let progress = metadata.progress.unwrap();
+        assert_eq!(progress.track_progress, 30000);
+        assert_eq!(progress.track_duration, 180000);
+        assert_eq!(progress.playback_speed, 1000);
+
+        // Test minimal payload with no metadata field
+        let minimal_json = r#"{
+  "type": "server/state",
+  "payload": {}
+}"#;
+        let msg: ServerStateMessage = serde_json::from_str(minimal_json).unwrap();
+        assert_eq!(msg.msg_type, "server/state");
+        assert!(msg.payload.metadata.is_none());
+    }
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -320,4 +320,52 @@ mod tests {
             assert_eq!(deserialized, mode);
         }
     }
+
+    #[test]
+    fn test_invalid_volume_control_mode_returns_error() {
+        let result = set_string_setting("volume_control_mode", Some("invalid".to_string()));
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err();
+        assert!(
+            error_msg.contains("Invalid volume control mode"),
+            "Expected error to contain 'Invalid volume control mode', got: {}",
+            error_msg
+        );
+    }
+
+    #[test]
+    fn test_malformed_json_deserializes_to_defaults() {
+        // Test that malformed JSON returns Err
+        let result = serde_json::from_str::<Settings>("not valid json");
+        assert!(result.is_err());
+
+        // Test that unwrap_or_default gives defaults
+        let settings = serde_json::from_str::<Settings>("not valid json").unwrap_or_default();
+        assert!(settings.discord_rpc_enabled);
+        assert_eq!(settings.software_volume, 100);
+        assert!(!settings.muted);
+    }
+
+    #[test]
+    fn test_unknown_setting_keys_return_errors() {
+        // Test unknown string setting key
+        let result = set_string_setting("nonexistent_key", Some("value".to_string()));
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err();
+        assert!(
+            error_msg.contains("Unknown string setting"),
+            "Expected error to contain 'Unknown string setting', got: {}",
+            error_msg
+        );
+
+        // Test unknown int setting key
+        let result = set_int_setting("nonexistent_key", 42);
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err();
+        assert!(
+            error_msg.contains("Unknown int setting"),
+            "Expected error to contain 'Unknown int setting', got: {}",
+            error_msg
+        );
+    }
 }


### PR DESCRIPTION
Spent a couple of hours throwing out the low-value tests the robot was suggesting, tried to keep only the good stuff.

Extract pure functions from Tauri commands where needed for testability: WS URL construction, mDNS IP parsing/selection, Discord timestamp calculation, and playback state logic.

Add table-driven tests for settings validation, protocol serialization, now-playing state management, and device sorting.

Fix trailing-slash bug in WebSocket URL construction.