### PR TITLE
fix(husky): switch to npx to fix windows tty issues

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 # Format staged files (prettier for JS/HTML/JSON/MD)
-yarn lint-staged
+npx --no-install lint-staged --quiet
 
 # Run Rust linting (format check + clippy)
 cd src-tauri && cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
Switch from yarn to npx --no-install to get around "stdin is not a tty" errors in Git Bash/Windows. 