### PR TITLE
Update for sendspin-rs v0.2.0 breaking API changes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "7c88dbbce13b232b26250e1e2e6ac18b6a891a646b8148285036ebce260ac5c3"
 dependencies = [
  "alsa-sys",
  "bitflags 2.10.0",
@@ -598,8 +598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -824,13 +822,16 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -844,25 +845,32 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "5b1f9c7312f19fc2fa12fd7acaf38de54e8320ba10d1a02dcbe21038def51ccb"
 dependencies = [
  "alsa",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
  "js-sys",
  "libc",
  "mach2",
- "ndk 0.8.0",
+ "ndk",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2 0.6.3",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.54.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -2446,16 +2454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,9 +2655,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -2869,20 +2867,6 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
-dependencies = [
- "bitflags 2.10.0",
- "jni-sys",
- "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -2890,7 +2874,7 @@ dependencies = [
  "bitflags 2.10.0",
  "jni-sys",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -2901,15 +2885,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -3078,6 +3053,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "objc2 0.6.3",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,6 +3086,29 @@ dependencies = [
  "bitflags 2.10.0",
  "objc2 0.6.3",
  "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.3",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -3106,7 +3129,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.3",
 ]
 
@@ -3304,29 +3329,6 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-javascript-core",
  "objc2-security",
-]
-
-[[package]]
-name = "oboe"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
-dependencies = [
- "jni",
- "ndk 0.8.0",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -4502,12 +4504,13 @@ dependencies = [
 
 [[package]]
 name = "sendspin"
-version = "0.1.0"
-source = "git+https://github.com/Sendspin/sendspin-rs?branch=main#6ea038f84286fd951d096e11f7e564d1560f036b"
+version = "0.2.0"
+source = "git+https://github.com/Sendspin/sendspin-rs?tag=v0.2.0#e19d64ee596808b894ceae5eb6c04941abf8d2c1"
 dependencies = [
  "cpal",
  "crossbeam",
  "futures-util",
+ "libc",
  "log",
  "parking_lot",
  "serde",
@@ -4992,9 +4995,9 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "ndk 0.9.0",
+ "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "objc2 0.6.3",
  "objc2-app-kit",
  "objc2-foundation 0.3.2",
@@ -6484,16 +6487,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -6522,16 +6515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6648,15 +6631,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7117,7 +7091,7 @@ dependencies = [
  "jni",
  "kuchikiki",
  "libc",
- "ndk 0.9.0",
+ "ndk",
  "objc2 0.6.3",
  "objc2-app-kit",
  "objc2-core-foundation",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,13 +33,12 @@ tauri-plugin-autostart = "2"
 tauri-plugin-clipboard-manager = "2"
 
 # Sendspin native client
-# Using phase3-artwork-visualizer branch for full protocol support (commands, state, artwork)
-cpal = "0.15"
+cpal = "0.17"
 futures-util = "0.3"
 hostname = "0.4"
 parking_lot = "0.12"
 png = "0.17"
-sendspin = {git = "https://github.com/Sendspin/sendspin-rs", branch = "main"}
+sendspin = {git = "https://github.com/Sendspin/sendspin-rs", tag = "v0.2.0"}
 tokio = {version = "1", features = ["sync", "macros", "time"] }
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 uuid = {version = "1", features = ["v4"] }

--- a/src-tauri/src/discord_rpc.rs
+++ b/src-tauri/src/discord_rpc.rs
@@ -106,8 +106,7 @@ fn update_discord_activity(
     // Calculate timestamps
     let current_time = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_millis() as i64);
 
     let (started, end) = calculate_discord_timestamps(np.elapsed, np.duration, current_time);
 

--- a/src-tauri/src/sendspin/devices.rs
+++ b/src-tauri/src/sendspin/devices.rs
@@ -25,7 +25,9 @@ pub struct AudioDevice {
 pub fn list_devices() -> Result<Vec<AudioDevice>, String> {
     let host = cpal::default_host();
 
-    let default_device_name = host.default_output_device().and_then(|d| d.name().ok());
+    let default_device_name = host
+        .default_output_device()
+        .and_then(|d| d.description().ok().map(|desc| desc.name().to_string()));
 
     let devices = host
         .output_devices()
@@ -34,9 +36,10 @@ pub fn list_devices() -> Result<Vec<AudioDevice>, String> {
     let mut result = Vec::new();
 
     for device in devices {
-        let Ok(name) = device.name() else {
-            continue; // Skip devices we can't get a name for
+        let Ok(desc) = device.description() else {
+            continue; // Skip devices we can't get a description for
         };
+        let name = desc.name().to_string();
 
         let is_default = default_device_name.as_ref().is_some_and(|d| d == &name);
 
@@ -48,8 +51,8 @@ pub fn list_devices() -> Result<Vec<AudioDevice>, String> {
 
                 for config in configs {
                     // Collect common sample rates that are supported
-                    let min_rate = config.min_sample_rate().0;
-                    let max_rate = config.max_sample_rate().0;
+                    let min_rate = config.min_sample_rate();
+                    let max_rate = config.max_sample_rate();
 
                     for &rate in &[44100, 48000, 88200, 96000, 176400, 192000] {
                         if rate >= min_rate && rate <= max_rate && !rates.contains(&rate) {
@@ -103,8 +106,8 @@ pub fn get_device_by_id(device_id: &str) -> Result<cpal::Device, String> {
         .map_err(|e| format!("Failed to enumerate devices: {}", e))?;
 
     for device in devices {
-        if let Ok(name) = device.name() {
-            if name == device_id {
+        if let Ok(desc) = device.description() {
+            if desc.name() == device_id {
                 return Ok(device);
             }
         }

--- a/src-tauri/src/sendspin/mod.rs
+++ b/src-tauri/src/sendspin/mod.rs
@@ -28,10 +28,12 @@ use tokio_tungstenite::{connect_async, tungstenite::protocol::Message as WsMessa
 use sendspin::audio::decode::{Decoder, PcmDecoder, PcmEndian};
 use sendspin::audio::{AudioBuffer, AudioFormat, Codec, SyncedPlayer};
 use sendspin::protocol::messages::{
-    AudioFormatSpec, ClientCommand, ClientHello, ClientState, ClientTime, ControllerCommand,
-    DeviceInfo, Message, PlayerState, PlayerSyncState, PlayerV1Support,
+    AudioFormatSpec, ClientCommand, ClientHello, ClientState, ClientSyncState, ClientTime,
+    ControllerCommand, ControllerCommandType, DeviceInfo, Message, PlayerCommandType, PlayerState,
+    PlayerV1Support, ServerCommand,
 };
 use sendspin::sync::ClockSync;
+use sendspin::{Clock, DefaultClock};
 
 /// Simple jitter: returns a pseudo-random value in `0..max_ms/4` using the
 /// current timestamp as entropy. No external crate needed.
@@ -547,10 +549,11 @@ fn save_volume_state(resolved_mode: ResolvedVolumeMode, volume: u8, muted: bool)
 /// back to the server. Returns `None` if serialization fails.
 fn build_volume_state_msg(volume: u8, muted: bool) -> Option<WsMessage> {
     let state = Message::ClientState(ClientState {
+        state: Some(ClientSyncState::Synchronized),
         player: Some(PlayerState {
-            state: PlayerSyncState::Synchronized,
             volume: Some(volume),
             muted: Some(muted),
+            ..PlayerState::default()
         }),
     });
     serde_json::to_string(&state)
@@ -607,20 +610,23 @@ async fn run_authenticated_client(
     let report_volume = (resolved_mode != ResolvedVolumeMode::None).then_some(initial_volume);
     let report_muted = (resolved_mode != ResolvedVolumeMode::None).then_some(initial_muted);
     let client_state = Message::ClientState(ClientState {
+        state: Some(ClientSyncState::Synchronized),
         player: Some(PlayerState {
-            state: PlayerSyncState::Synchronized,
             volume: report_volume,
             muted: report_muted,
+            ..PlayerState::default()
         }),
     });
     let state_json = serde_json::to_string(&client_state)?;
     ws_tx.send(WsMessage::Text(state_json.into())).await?;
 
+    // Raw monotonic clock used for t1/t4 timestamps. v0.2.0 of sendspin-rs
+    // requires t1/t4 to come from a Clock impl (NTP-immune monotonic source)
+    // rather than wall-clock time, so the Kalman filter sees a stable timebase.
+    let clock: Arc<dyn Clock> = Arc::new(DefaultClock::new());
+
     // Send initial clock sync
-    let client_transmitted = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_micros() as i64;
+    let client_transmitted = clock.now_micros();
     let time_msg = Message::ClientTime(ClientTime { client_transmitted });
     let time_json = serde_json::to_string(&time_msg)?;
     ws_tx.send(WsMessage::Text(time_json.into())).await?;
@@ -629,7 +635,7 @@ async fn run_authenticated_client(
     let mut clock_sync_interval = tokio::time::interval(Duration::from_secs(5));
 
     // Create shared clock sync with Kalman filter-based drift correction
-    let clock_sync = Arc::new(Mutex::new(ClockSync::new()));
+    let clock_sync = Arc::new(Mutex::new(ClockSync::new(Arc::clone(&clock))));
 
     // Get audio device
     let device = if let Some(ref device_id) = config.audio_device_id {
@@ -678,20 +684,28 @@ async fn run_authenticated_client(
                 break;
             }
             _ = clock_sync_interval.tick() => {
-                // Send periodic clock sync
-                let client_transmitted = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_micros() as i64;
+                // Send periodic clock sync (raw monotonic timebase per Clock trait)
+                let client_transmitted = clock.now_micros();
                 let time_msg = Message::ClientTime(ClientTime { client_transmitted });
                 if let Ok(json) = serde_json::to_string(&time_msg) {
                     let _ = ws_tx.send(WsMessage::Text(json.into())).await;
                 }
             }
             Some(cmd) = command_rx.recv() => {
+                let command_type = match cmd.as_str() {
+                    "play" => ControllerCommandType::Play,
+                    "pause" => ControllerCommandType::Pause,
+                    "stop" => ControllerCommandType::Stop,
+                    "next" => ControllerCommandType::Next,
+                    "previous" => ControllerCommandType::Previous,
+                    _ => {
+                        eprintln!("[Sendspin] Unknown command: {}", cmd);
+                        continue;
+                    }
+                };
                 let command_msg = Message::ClientCommand(ClientCommand {
                     controller: Some(ControllerCommand {
-                        command: cmd,
+                        command: command_type,
                         volume: None,
                         mute: None,
                     }),
@@ -748,11 +762,10 @@ async fn run_authenticated_client(
                                     playback_started = false;
                                 }
                                 Message::ServerTime(server_time) => {
-                                    // Update clock sync with drift tracking
-                                    let t4 = SystemTime::now()
-                                        .duration_since(UNIX_EPOCH)
-                                        .unwrap()
-                                        .as_micros() as i64;
+                                    // Update clock sync with drift tracking. t1 (client_transmitted)
+                                    // was generated from `clock.now_micros()` when we sent ClientTime,
+                                    // so t4 must come from the same clock for the RTT math to work.
+                                    let t4 = clock.now_micros();
 
                                     let t1 = server_time.client_transmitted;
                                     let t2 = server_time.server_received;
@@ -784,93 +797,86 @@ async fn run_authenticated_client(
                                     let _ = player_tx.send(PlayerCommand::Clear);
                                     playback_started = false;
                                 }
-                                _ => {
-                                    // Try to parse as generic message for server commands
-                                    if let Ok(generic) = serde_json::from_str::<serde_json::Value>(&text) {
-                                        if let Some(msg_type) = generic.get("type").and_then(|v| v.as_str()) {
-                                            if msg_type == "server/command" {
-                                                // Handle server command for player control
-                                                if let Some(payload) = generic.get("payload") {
-                                                    if let Some(player_cmd) = payload.get("player") {
-                                                        // Handle volume command
-                                                        if let Some(volume) = player_cmd.get("volume").and_then(|v| v.as_u64()) {
-                                                            let vol = (volume as u8).min(100);
+                                Message::ServerCommand(ServerCommand { player: Some(player_cmd) }) => {
+                                    // Handle volume command
+                                    if player_cmd.command == PlayerCommandType::Volume {
+                                        if let Some(volume) = player_cmd.volume {
+                                            let vol = volume.min(100);
 
-                                                            let success = match resolved_mode {
-                                                                ResolvedVolumeMode::Hardware => {
-                                                                    let volume_result = {
-                                                                        let vol_ctrl = VOLUME_CONTROLLER.read();
-                                                                        if let Some(ref vc) = *vol_ctrl {
-                                                                            vc.set_volume(vol)
-                                                                        } else {
-                                                                            Err("Volume controller not available".to_string())
-                                                                        }
-                                                                    };
-                                                                    if let Err(e) = &volume_result {
-                                                                        eprintln!("[Sendspin] Failed to set hardware volume: {}", e);
-                                                                    }
-                                                                    volume_result.is_ok()
-                                                                }
-                                                                ResolvedVolumeMode::Software => {
-                                                                    let _ = player_tx.send(PlayerCommand::SetVolume(vol));
-                                                                    true // Software volume always succeeds (command queued)
-                                                                }
-                                                                ResolvedVolumeMode::None => {
-                                                                    eprintln!("[Sendspin] Ignoring volume command: volume control is disabled");
-                                                                    false
-                                                                }
-                                                            };
-
-                                                            if success {
-                                                                current_volume = vol;
-                                                                save_volume_state(resolved_mode, current_volume, current_muted);
-                                                                if let Some(msg) = build_volume_state_msg(current_volume, current_muted) {
-                                                                    let _ = ws_tx.send(msg).await;
-                                                                }
-                                                            }
+                                            let success = match resolved_mode {
+                                                ResolvedVolumeMode::Hardware => {
+                                                    let volume_result = {
+                                                        let vol_ctrl = VOLUME_CONTROLLER.read();
+                                                        if let Some(ref vc) = *vol_ctrl {
+                                                            vc.set_volume(vol)
+                                                        } else {
+                                                            Err("Volume controller not available".to_string())
                                                         }
-
-                                                        // Handle mute command
-                                                        if let Some(mute) = player_cmd.get("mute").and_then(|v| v.as_bool()) {
-                                                            let success = match resolved_mode {
-                                                                ResolvedVolumeMode::Hardware => {
-                                                                    let mute_result = {
-                                                                        let vol_ctrl = VOLUME_CONTROLLER.read();
-                                                                        if let Some(ref vc) = *vol_ctrl {
-                                                                            vc.set_mute(mute)
-                                                                        } else {
-                                                                            Err("Volume controller not available".to_string())
-                                                                        }
-                                                                    };
-                                                                    if let Err(e) = &mute_result {
-                                                                        eprintln!("[Sendspin] Failed to set hardware mute: {}", e);
-                                                                    }
-                                                                    mute_result.is_ok()
-                                                                }
-                                                                ResolvedVolumeMode::Software => {
-                                                                    let _ = player_tx.send(PlayerCommand::SetMute(mute));
-                                                                    true
-                                                                }
-                                                                ResolvedVolumeMode::None => {
-                                                                    eprintln!("[Sendspin] Ignoring mute command: volume control is disabled");
-                                                                    false
-                                                                }
-                                                            };
-
-                                                            if success {
-                                                                current_muted = mute;
-                                                                save_volume_state(resolved_mode, current_volume, current_muted);
-                                                                if let Some(msg) = build_volume_state_msg(current_volume, current_muted) {
-                                                                    let _ = ws_tx.send(msg).await;
-                                                                }
-                                                            }
-                                                        }
+                                                    };
+                                                    if let Err(e) = &volume_result {
+                                                        eprintln!("[Sendspin] Failed to set hardware volume: {}", e);
                                                     }
+                                                    volume_result.is_ok()
+                                                }
+                                                ResolvedVolumeMode::Software => {
+                                                    let _ = player_tx.send(PlayerCommand::SetVolume(vol));
+                                                    true
+                                                }
+                                                ResolvedVolumeMode::None => {
+                                                    eprintln!("[Sendspin] Ignoring volume command: volume control is disabled");
+                                                    false
+                                                }
+                                            };
+
+                                            if success {
+                                                current_volume = vol;
+                                                save_volume_state(resolved_mode, current_volume, current_muted);
+                                                if let Some(msg) = build_volume_state_msg(current_volume, current_muted) {
+                                                    let _ = ws_tx.send(msg).await;
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // Handle mute command
+                                    if player_cmd.command == PlayerCommandType::Mute {
+                                        if let Some(mute) = player_cmd.mute {
+                                            let success = match resolved_mode {
+                                                ResolvedVolumeMode::Hardware => {
+                                                    let mute_result = {
+                                                        let vol_ctrl = VOLUME_CONTROLLER.read();
+                                                        if let Some(ref vc) = *vol_ctrl {
+                                                            vc.set_mute(mute)
+                                                        } else {
+                                                            Err("Volume controller not available".to_string())
+                                                        }
+                                                    };
+                                                    if let Err(e) = &mute_result {
+                                                        eprintln!("[Sendspin] Failed to set hardware mute: {}", e);
+                                                    }
+                                                    mute_result.is_ok()
+                                                }
+                                                ResolvedVolumeMode::Software => {
+                                                    let _ = player_tx.send(PlayerCommand::SetMute(mute));
+                                                    true
+                                                }
+                                                ResolvedVolumeMode::None => {
+                                                    eprintln!("[Sendspin] Ignoring mute command: volume control is disabled");
+                                                    false
+                                                }
+                                            };
+
+                                            if success {
+                                                current_muted = mute;
+                                                save_volume_state(resolved_mode, current_volume, current_muted);
+                                                if let Some(msg) = build_volume_state_msg(current_volume, current_muted) {
+                                                    let _ = ws_tx.send(msg).await;
                                                 }
                                             }
                                         }
                                     }
                                 }
+                                _ => {}
                             }
                         }
                     }


### PR DESCRIPTION
Adapt to the breaking changes that landed in sendspin-rs between our previous pin and the v0.2.0 release:

- ClientState gained `state: Option<ClientSyncState>` and PlayerState lost its sync state field; switch to ClientSyncState::Synchronized at the ClientState level and use PlayerState::default() to absorb newly-added optional fields (static_delay_ms, supported_commands).
- ControllerCommand.command moved from String to ControllerCommandType; add a string→enum mapping at the command channel boundary.
- ServerCommand is now a typed Message variant with PlayerCommandType, replacing the manual JSON parsing of `server/command` payloads.
- ClockSync::new() now requires Arc<dyn Clock>; t1/t4 must come from Clock::now_micros() (raw monotonic, NTP-immune) rather than SystemTime::now() against UNIX_EPOCH.
- Bump cpal 0.15 → 0.17 to match the version sendspin-rs leaks through its public API (SyncedPlayer takes cpal::Device); update device enumeration for cpal 0.17's deprecation of name() in favour of description() and the SampleRate wrapper removal.