### PR TITLE
Fix .desktop Exec to match Tauri binary name

### DIFF
--- a/music-assistant.desktop
+++ b/music-assistant.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Categories=Music
 Comment=Music Assistant Desktop App
-Exec=music-assistant-desktop
+Exec=music-assistant-companion
 Icon=music-assistant
 Name=Music Assistant
 Terminal=false


### PR DESCRIPTION
The .desktop file referenced music-assistant-desktop, but the Tauri bundle produces music-assistant-companion (mainBinaryName in tauri.conf.json). Update Exec to match so launchers actually start the app.

Fixes #29