### PR TITLE
Fix blank WebView / Wayland crash on Linux by disabling WebKitGTK DMABUF renderer

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,15 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // WebKitGTK's DMABUF renderer fails on several common Linux setups
+    // (notably NVIDIA drivers and some Wayland compositors), producing either
+    // a blank white WebView or a Wayland `Error 71 (Protocol error)` crash
+    // on launch. Disable it by default; users can opt back in by exporting
+    // the variable themselves before launching the app.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     app_lib::run();
 }


### PR DESCRIPTION
## Summary

- On several common Linux setups — notably NVIDIA proprietary drivers
  and some Wayland compositors — WebKitGTK's DMABUF renderer fails and
  the Tauri WebView either renders as a blank white window or crashes
  on launch with `Gdk-Message: Error 71 (Protocol error) dispatching to
  Wayland display`.
- This is a long-standing WebKitGTK issue, not a Tauri or app bug, but
  end users experience it as "the Music Assistant desktop app just shows
  a white screen" or "won't launch at all".
- Fix: set `WEBKIT_DISABLE_DMABUF_RENDERER=1` from `main()` before Tauri
  initializes the WebView. Only done on `target_os = "linux"`, and only
  when the user hasn't already set the variable — so advanced users can
  still opt back in to DMABUF rendering. macOS and Windows builds are
  unaffected.

Reproduction (before the fix) on Fedora 43 + KDE Wayland + NVIDIA open
driver 580.x:

```
$ npm run dev
...
Gdk-Message: 09:14:42.801: Error 71 (Protocol error) dispatching to Wayland display.
```

With the fix in place, `npm run dev` launches cleanly into the WebView,
no env prefix needed.

This is the same workaround adopted by several other Tauri/WebKitGTK
apps in the wild (Bitwarden, Meetily, etc.).

## Test plan

- [x] `cd src-tauri && cargo fmt --check` — clean
- [x] `yarn lint:rust` (clippy pedantic, -D warnings) — clean
- [x] `npm run dev` on Linux + NVIDIA + Wayland — launches, WebView
  renders, no Wayland protocol error
- [ ] Verify on a non-NVIDIA Linux host that the app still launches
  normally (the flag is a no-op on systems where DMABUF already works)
- [ ] macOS + Windows build unaffected (guarded by `#[cfg(target_os = "linux")]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)