### PR TITLE
feat: add setting to toggle menubar/tray icon

### DIFF
--- a/src-tauri/resources/settings.html
+++ b/src-tauri/resources/settings.html
@@ -346,6 +346,20 @@
           />
           <label for="autostart-toggle" class="toggle-label"></label>
         </div>
+        <div class="setting-item">
+          <div class="setting-label">
+            <label for="tray-toggle">Show menubar icon</label>
+            <small id="desc-tray">Display an icon in the system tray / menubar</small>
+          </div>
+          <input
+            type="checkbox"
+            id="tray-toggle"
+            class="sr-only"
+            onchange="toggleTrayIcon()"
+            aria-describedby="desc-tray"
+          />
+          <label for="tray-toggle" class="toggle-label"></label>
+        </div>
       </section>
 
       <section class="setting-group" aria-labelledby="heading-audio-output">
@@ -734,6 +748,7 @@
           document.getElementById("discord-toggle").checked = settings.discord_rpc_enabled === true;
           document.getElementById("minimized-toggle").checked = settings.start_minimized === true;
           document.getElementById("autostart-toggle").checked = settings.autostart === true;
+          document.getElementById("tray-toggle").checked = settings.show_tray_icon !== false;
           document.getElementById("sendspin-toggle").checked = settings.sendspin_enabled === true;
 
           // Set sync delay slider
@@ -794,6 +809,12 @@
         const toggle = document.getElementById("autostart-toggle");
         await invoke("set_setting", { key: "autostart", value: toggle.checked });
         announceSettingChange(`Launch at login ${toggle.checked ? "enabled" : "disabled"}`);
+      }
+
+      async function toggleTrayIcon() {
+        const toggle = document.getElementById("tray-toggle");
+        await invoke("set_setting", { key: "show_tray_icon", value: toggle.checked });
+        announceSettingChange(`Menubar icon ${toggle.checked ? "enabled" : "disabled"}`);
       }
 
       async function toggleSendspin() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -260,6 +260,14 @@ fn start_services(app_handle: tauri::AppHandle) {
     });
 }
 
+pub fn set_tray_visible(visible: bool) {
+    if let Ok(tray_guard) = TRAY_ICON.try_lock() {
+        if let Some(ref tray) = *tray_guard {
+            let _ = tray.set_visible(visible);
+        }
+    }
+}
+
 /// Update the tray tooltip and menu item with now-playing info
 /// Spawns on a separate thread to avoid blocking the caller, since
 /// tray operations on macOS dispatch synchronously to the main thread
@@ -824,6 +832,11 @@ pub fn run() {
             // Store tray reference for tooltip updates
             if let Ok(mut tray_guard) = TRAY_ICON.lock() {
                 *tray_guard = Some(tray);
+            }
+
+            // Apply initial tray visibility from settings
+            if !loaded_settings.show_tray_icon {
+                set_tray_visible(false);
             }
 
             // Add "Preferences..." (CmdOrCtrl+,) to the default menu bar.

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -54,10 +54,17 @@ pub struct Settings {
     // since mute is lost on every reconnect (new connection per track).
     #[serde(default)]
     pub muted: bool,
+    // Whether to show the menubar/system tray icon
+    #[serde(default = "default_show_tray_icon")]
+    pub show_tray_icon: bool,
 }
 
 fn default_software_volume() -> u8 {
     100
+}
+
+fn default_show_tray_icon() -> bool {
+    true
 }
 
 fn default_player_name() -> String {
@@ -95,6 +102,7 @@ impl Default for Settings {
             volume_control_mode: VolumeControlMode::default(),
             software_volume: default_software_volume(),
             muted: false,
+            show_tray_icon: true,
         }
     }
 }
@@ -114,6 +122,7 @@ static SETTINGS: RwLock<Settings> = RwLock::new(Settings {
     volume_control_mode: VolumeControlMode::Auto,
     software_volume: 100,
     muted: false,
+    show_tray_icon: true,
 });
 
 fn get_settings_path() -> Option<PathBuf> {
@@ -201,6 +210,10 @@ pub fn set_setting(app: tauri::AppHandle, key: &str, value: bool) -> Result<(), 
             }
             // Note: When enabling, frontend should reload or call configure_sendspin
             // to start the client with proper auth token
+        }
+        "show_tray_icon" => {
+            settings.show_tray_icon = value;
+            crate::set_tray_visible(value);
         }
         _ => return Err(format!("Unknown boolean setting: {}", key)),
     }


### PR DESCRIPTION
## Summary

- Adds a `show_tray_icon` boolean setting (defaults to `true`) to the settings store
- Toggling it off hides the system tray / menubar icon immediately at runtime and persists across restarts
- Added a **Show menubar icon** toggle in the Behavior section of the Settings UI
- Settings are still accessible via the app menu bar (Edit → Preferences…) when the tray is hidden

## Test plan

- [x] Toggle off the menubar icon in Settings — icon disappears immediately
- [x] Restart the app — icon stays hidden
- [x] Toggle it back on — icon reappears
- [x] Verify Settings window is still reachable via the menu bar when tray is hidden
- [x] Verify existing settings (Discord, autostart, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)