### PR TITLE
Ignore Now Playing updates when sendspin client is active

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -168,12 +168,6 @@ fn get_now_playing() -> NowPlaying {
     now_playing::get_now_playing()
 }
 
-/// Update now-playing information (called from frontend when track changes)
-#[tauri::command]
-fn update_now_playing(now_playing: NowPlaying) {
-    now_playing::update_now_playing(now_playing);
-}
-
 /// Initialize desktop integrations (Discord RPC, tray updates, media controls)
 /// Call this after connecting to the MA server
 #[tauri::command]
@@ -547,7 +541,6 @@ pub fn run() {
             companion_ready,
             navigate_to_launcher,
             get_now_playing,
-            update_now_playing,
             start_desktop_services,
             start_discord_rpc,
             start_rpc,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -168,6 +168,23 @@ fn get_now_playing() -> NowPlaying {
     now_playing::get_now_playing()
 }
 
+/// Update now-playing information (called from frontend when track changes)
+#[tauri::command]
+fn update_now_playing(now_playing: NowPlaying) {
+    let sendspin_player_id = sendspin::get_player_id();
+    let current_now_playing = now_playing::get_now_playing();
+
+    // Filter out frontend updates when Sendspin is active
+    if current_now_playing.player_id.as_deref() == sendspin_player_id.as_deref()
+        && current_now_playing.is_playing
+    {
+        log::info!("[Tauri] Ignoring now-playing update from frontend because Sendspin is active");
+        return;
+    }
+
+    now_playing::update_now_playing(now_playing);
+}
+
 /// Initialize desktop integrations (Discord RPC, tray updates, media controls)
 /// Call this after connecting to the MA server
 #[tauri::command]
@@ -541,6 +558,7 @@ pub fn run() {
             companion_ready,
             navigate_to_launcher,
             get_now_playing,
+            update_now_playing,
             start_desktop_services,
             start_discord_rpc,
             start_rpc,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -178,7 +178,7 @@ fn update_now_playing(now_playing: NowPlaying) {
     if current_now_playing.player_id.as_deref() == sendspin_player_id.as_deref()
         && current_now_playing.is_playing
     {
-        log::info!("[Tauri] Ignoring now-playing update from frontend because Sendspin is active");
+        log::debug!("[Tauri] Ignoring now-playing update from frontend because Sendspin is active");
         return;
     }
 


### PR DESCRIPTION
When the internal sendspin client is active, we should ignore incoming now playing updates from the frontend.
Because the frontend can have a different player connected, resulting in conflicting statuses being used.

The internal sendspin client will now always win with it's now playing status, only when it's not enabled or playing something will the frontend command be accepted to process.

Fixes https://github.com/music-assistant/desktop-app/issues/51
