### PR TITLE
Add ability to show now playing in the tray

### DIFF
--- a/src-tauri/resources/settings.html
+++ b/src-tauri/resources/settings.html
@@ -376,6 +376,22 @@
           />
           <label for="tray-toggle" class="toggle-label"></label>
         </div>
+        <div class="setting-item">
+          <div class="setting-label">
+            <label for="tray-now-playing-toggle">Show now-playing title</label>
+            <small id="desc-tray-now-playing"
+              >Display track text next to the system tray / menubar icon</small
+            >
+          </div>
+          <input
+            type="checkbox"
+            id="tray-now-playing-toggle"
+            class="sr-only"
+            onchange="toggleTrayNowPlaying()"
+            aria-describedby="desc-tray-now-playing"
+          />
+          <label for="tray-now-playing-toggle" class="toggle-label"></label>
+        </div>
       </section>
 
       <section class="setting-group" aria-labelledby="heading-audio-output">
@@ -766,6 +782,8 @@
           document.getElementById("close-to-tray-toggle").checked = settings.close_to_tray === true;
           document.getElementById("autostart-toggle").checked = settings.autostart === true;
           document.getElementById("tray-toggle").checked = settings.show_tray_icon !== false;
+          document.getElementById("tray-now-playing-toggle").checked =
+            settings.show_tray_now_playing === true;
           document.getElementById("sendspin-toggle").checked = settings.sendspin_enabled === true;
 
           // Set sync delay slider
@@ -838,6 +856,12 @@
         const toggle = document.getElementById("tray-toggle");
         await invoke("set_setting", { key: "show_tray_icon", value: toggle.checked });
         announceSettingChange(`Menubar icon ${toggle.checked ? "enabled" : "disabled"}`);
+      }
+
+      async function toggleTrayNowPlaying() {
+        const toggle = document.getElementById("tray-now-playing-toggle");
+        await invoke("set_setting", { key: "show_tray_now_playing", value: toggle.checked });
+        announceSettingChange(`Now-playing title ${toggle.checked ? "enabled" : "disabled"}`);
       }
 
       async function toggleSendspin() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -281,26 +281,26 @@ fn update_tray_now_playing(np: &NowPlaying) {
     // Spawn tray update on a separate thread to never block the caller
     thread::spawn(move || {
         let tooltip = now_playing::format_now_playing_with_player(&np);
-        let title = if settings::get_settings().show_tray_now_playing {
-            now_playing::format_now_playing(&np, false)
+        let title = if settings::get_settings().show_tray_now_playing && np.is_playing {
+            now_playing::format_now_playing(&np)
         } else {
-            None
+            String::new()
         };
 
         // Update tray metadata - use try_lock to avoid blocking
         if let Ok(tray_guard) = TRAY_ICON.try_lock() {
             if let Some(ref tray) = *tray_guard {
-                let _ = tray.set_title(Some(title.as_deref().unwrap_or("")));
+                let _ = tray.set_title(Some(&title));
                 let _ = tray.set_tooltip(Some(&tooltip));
             }
         }
 
+        let now_playing_text = now_playing::format_now_playing(&np);
+        let menu_text = format!("♪ {now_playing_text}");
+
         if let Ok(item_guard) = NOW_PLAYING_MENU_ITEM.try_lock() {
             if let Some(ref item) = *item_guard {
-                if let Some(now_playing_text) = now_playing::format_now_playing(&np, true) {
-                    let menu_text = format!("♪ {now_playing_text}");
-                    let _ = item.set_text(&menu_text);
-                }
+                let _ = item.set_text(&menu_text);
             }
         }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -290,7 +290,7 @@ fn update_tray_now_playing(np: &NowPlaying) {
         // Update tray metadata - use try_lock to avoid blocking
         if let Ok(tray_guard) = TRAY_ICON.try_lock() {
             if let Some(ref tray) = *tray_guard {
-                let _ = tray.set_title(title.as_deref());
+                let _ = tray.set_title(Some(title.as_deref().unwrap_or("")));
                 let _ = tray.set_tooltip(Some(&tooltip));
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -268,6 +268,10 @@ pub fn set_tray_visible(visible: bool) {
     }
 }
 
+pub fn refresh_tray_now_playing() {
+    update_tray_now_playing(&now_playing::get_now_playing());
+}
+
 /// Update the tray title, tooltip, and menu item with now-playing info
 /// Spawns on a separate thread to avoid blocking the caller, since
 /// tray operations on macOS dispatch synchronously to the main thread
@@ -277,7 +281,11 @@ fn update_tray_now_playing(np: &NowPlaying) {
     // Spawn tray update on a separate thread to never block the caller
     thread::spawn(move || {
         let tooltip = now_playing::format_now_playing_with_player(&np);
-        let title = now_playing::format_now_playing(&np, false);
+        let title = if settings::get_settings().show_tray_now_playing {
+            now_playing::format_now_playing(&np, false)
+        } else {
+            None
+        };
 
         // Update tray metadata - use try_lock to avoid blocking
         if let Ok(tray_guard) = TRAY_ICON.try_lock() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -268,7 +268,7 @@ pub fn set_tray_visible(visible: bool) {
     }
 }
 
-pub fn refresh_tray_now_playing() {
+pub(crate) fn refresh_tray_now_playing() {
     update_tray_now_playing(&now_playing::get_now_playing());
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -201,9 +201,9 @@ fn start_services(app_handle: tauri::AppHandle) {
     }
 
     SERVICES_STARTER.call_once(move || {
-        // Register callback to update tray tooltip and media controls when now-playing changes
+        // Register callback to update tray now-playing state and media controls when playback changes
         now_playing::on_now_playing_change(Arc::new(|np| {
-            update_tray_tooltip(np);
+            update_tray_now_playing(np);
             media_controls::update(np);
         }));
 
@@ -268,35 +268,31 @@ pub fn set_tray_visible(visible: bool) {
     }
 }
 
-/// Update the tray tooltip and menu item with now-playing info
+/// Update the tray title, tooltip, and menu item with now-playing info
 /// Spawns on a separate thread to avoid blocking the caller, since
 /// tray operations on macOS dispatch synchronously to the main thread
-fn update_tray_tooltip(np: &NowPlaying) {
+fn update_tray_now_playing(np: &NowPlaying) {
     let np = np.clone();
 
     // Spawn tray update on a separate thread to never block the caller
     thread::spawn(move || {
         let tooltip = now_playing::format_now_playing_with_player(&np);
+        let title = now_playing::format_now_playing(&np, false);
 
-        // Update tooltip - use try_lock to avoid blocking
+        // Update tray metadata - use try_lock to avoid blocking
         if let Ok(tray_guard) = TRAY_ICON.try_lock() {
             if let Some(ref tray) = *tray_guard {
+                let _ = tray.set_title(title.as_deref());
                 let _ = tray.set_tooltip(Some(&tooltip));
             }
         }
 
-        // Update menu item text
-        let menu_text = if np.is_playing {
-            let track = np.track.as_deref().unwrap_or("Unknown");
-            let artist = np.artist.as_deref().unwrap_or("Unknown");
-            format!("♪ {} - {}", artist, track)
-        } else {
-            "♪ Not Playing".to_string()
-        };
-
         if let Ok(item_guard) = NOW_PLAYING_MENU_ITEM.try_lock() {
             if let Some(ref item) = *item_guard {
-                let _ = item.set_text(&menu_text);
+                if let Some(now_playing_text) = now_playing::format_now_playing(&np, true) {
+                    let menu_text = format!("♪ {now_playing_text}");
+                    let _ = item.set_text(&menu_text);
+                }
             }
         }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -282,15 +282,15 @@ fn update_tray_now_playing(np: &NowPlaying) {
     thread::spawn(move || {
         let tooltip = now_playing::format_now_playing_with_player(&np);
         let title = if settings::get_settings().show_tray_now_playing && np.is_playing {
-            now_playing::format_now_playing(&np)
+            Some(now_playing::format_now_playing(&np))
         } else {
-            String::new()
+            None
         };
 
         // Update tray metadata - use try_lock to avoid blocking
         if let Ok(tray_guard) = TRAY_ICON.try_lock() {
             if let Some(ref tray) = *tray_guard {
-                let _ = tray.set_title(Some(&title));
+                let _ = tray.set_title(Some(title.as_deref().unwrap_or("")));
                 let _ = tray.set_tooltip(Some(&tooltip));
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -290,6 +290,7 @@ fn update_tray_now_playing(np: &NowPlaying) {
         // Update tray metadata - use try_lock to avoid blocking
         if let Ok(tray_guard) = TRAY_ICON.try_lock() {
             if let Some(ref tray) = *tray_guard {
+                // TODO: Remove unwrapping need when https://github.com/tauri-apps/tray-icon/issues/322 gets fixed
                 let _ = tray.set_title(Some(title.as_deref().unwrap_or("")));
                 let _ = tray.set_tooltip(Some(&tooltip));
             }

--- a/src-tauri/src/now_playing.rs
+++ b/src-tauri/src/now_playing.rs
@@ -92,7 +92,7 @@ pub fn update_now_playing(now_playing: NowPlaying) {
     }
 }
 
-/// Format now-playing info, optionally falling back to default status text.
+/// Format now-playing info for display (e.g., tray tooltip)
 pub fn format_now_playing(np: &NowPlaying) -> String {
     if !np.is_playing {
         return "Not Playing".to_string();

--- a/src-tauri/src/now_playing.rs
+++ b/src-tauri/src/now_playing.rs
@@ -92,17 +92,16 @@ pub fn update_now_playing(now_playing: NowPlaying) {
     }
 }
 
-/// Format now-playing info for display (e.g., tray tooltip)
-#[allow(dead_code)]
-pub fn format_now_playing(np: &NowPlaying) -> String {
+/// Format now-playing info, optionally falling back to default status text.
+pub fn format_now_playing(np: &NowPlaying, use_default: bool) -> Option<String> {
     if !np.is_playing {
-        return "Music Assistant - Not Playing".to_string();
+        return use_default.then(|| "Not Playing".to_string());
     }
 
     match (&np.artist, &np.track) {
-        (Some(artist), Some(track)) => format!("{} - {}", artist, track),
-        (None, Some(track)) => track.clone(),
-        _ => "Music Assistant - Playing".to_string(),
+        (Some(artist), Some(track)) => Some(format!("{artist} - {track}")),
+        (None, Some(track)) => Some(track.clone()),
+        _ => use_default.then(|| "Playing".to_string()),
     }
 }
 

--- a/src-tauri/src/now_playing.rs
+++ b/src-tauri/src/now_playing.rs
@@ -93,15 +93,15 @@ pub fn update_now_playing(now_playing: NowPlaying) {
 }
 
 /// Format now-playing info, optionally falling back to default status text.
-pub fn format_now_playing(np: &NowPlaying, use_default: bool) -> Option<String> {
+pub fn format_now_playing(np: &NowPlaying) -> String {
     if !np.is_playing {
-        return use_default.then(|| "Not Playing".to_string());
+        return "Not Playing".to_string();
     }
 
     match (&np.artist, &np.track) {
-        (Some(artist), Some(track)) => Some(format!("{artist} - {track}")),
-        (None, Some(track)) => Some(track.clone()),
-        _ => use_default.then(|| "Playing".to_string()),
+        (Some(artist), Some(track)) => format!("{artist} - {track}"),
+        (None, Some(track)) => track.clone(),
+        _ => "Playing".to_string(),
     }
 }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -59,6 +59,9 @@ pub struct Settings {
     // Whether to show the menubar/system tray icon
     #[serde(default = "default_show_tray_icon")]
     pub show_tray_icon: bool,
+    // Whether to show now-playing text next to the menubar/system tray icon
+    #[serde(default)]
+    pub show_tray_now_playing: bool,
 }
 
 fn default_close_to_tray() -> bool {
@@ -110,6 +113,7 @@ impl Default for Settings {
             software_volume: default_software_volume(),
             muted: false,
             show_tray_icon: true,
+            show_tray_now_playing: false,
         }
     }
 }
@@ -131,6 +135,7 @@ static SETTINGS: RwLock<Settings> = RwLock::new(Settings {
     software_volume: 100,
     muted: false,
     show_tray_icon: true,
+    show_tray_now_playing: false,
 });
 
 fn get_settings_path() -> Option<PathBuf> {
@@ -223,6 +228,10 @@ pub fn set_setting(app: tauri::AppHandle, key: &str, value: bool) -> Result<(), 
         "show_tray_icon" => {
             settings.show_tray_icon = value;
             crate::set_tray_visible(value);
+        }
+        "show_tray_now_playing" => {
+            settings.show_tray_now_playing = value;
+            crate::refresh_tray_now_playing();
         }
         _ => return Err(format!("Unknown boolean setting: {}", key)),
     }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -192,6 +192,7 @@ pub fn get_settings() -> Settings {
 
 pub fn set_setting(app: tauri::AppHandle, key: &str, value: bool) -> Result<(), String> {
     let mut settings = get_settings();
+    let mut should_refresh_tray_now_playing = false;
 
     match key {
         "discord_rpc_enabled" => {
@@ -231,12 +232,18 @@ pub fn set_setting(app: tauri::AppHandle, key: &str, value: bool) -> Result<(), 
         }
         "show_tray_now_playing" => {
             settings.show_tray_now_playing = value;
-            crate::refresh_tray_now_playing();
+            should_refresh_tray_now_playing = true;
         }
         _ => return Err(format!("Unknown boolean setting: {}", key)),
     }
 
-    save_settings(&settings)
+    save_settings(&settings)?;
+
+    if should_refresh_tray_now_playing {
+        crate::refresh_tray_now_playing();
+    }
+
+    Ok(())
 }
 
 /// Set a string setting value


### PR DESCRIPTION
This PR adds a setting that allows the system tray to show the current Now Playing status next to the icon (on supported platforms, macOS is supported, not sure about the others).

We clear the title when nothing is playing or when the setting is disabled, we could also show 'Not playing' when nothing is playing, but just keeping it as an icon might be preferred.

<img width="156" height="36" alt="image" src="https://github.com/user-attachments/assets/3945a52f-a1c6-458e-a1a4-ae54766433b5" />
