### PR TITLE
Mark discord activity as Listening

### DIFF
--- a/src-tauri/src/discord_rpc.rs
+++ b/src-tauri/src/discord_rpc.rs
@@ -1,7 +1,7 @@
 use crate::now_playing::{self, NowPlaying};
 use crate::DISCORD_RPC_ENABLED;
 use discord_rich_presence::{
-    activity::{self, StatusDisplayType},
+    activity::{self, ActivityType, StatusDisplayType},
     DiscordIpc, DiscordIpcClient,
 };
 use std::sync::atomic::Ordering;
@@ -132,6 +132,7 @@ fn update_discord_activity(
         .assets(assets)
         .buttons(buttons)
         .timestamps(timestamps)
+        .activity_type(ActivityType::Listening)
         .status_display_type(StatusDisplayType::Details);
 
     client.set_activity(payload)?;


### PR DESCRIPTION
A minor adjustment to the Discord Rich Presence, by marking the activity as a Listening session.
Fixes https://github.com/music-assistant/desktop-app/issues/44

Old version:
<img width="365" height="175" alt="image" src="https://github.com/user-attachments/assets/b4f93fae-e48f-437b-af1d-99e683b89752" />

New version:
<img width="361" height="180" alt="image" src="https://github.com/user-attachments/assets/21e88501-838e-42fa-b5f3-e86d0e572e23" />
