### PR TITLE
fix: trustworthy native now-playing via NowPlayingState accumulator

### DIFF
--- a/src-tauri/src/sendspin/mod.rs
+++ b/src-tauri/src/sendspin/mod.rs
@@ -8,10 +8,12 @@
 //! - Metadata role for receiving track info
 
 pub mod devices;
+mod now_playing_state;
 pub mod protocol;
 pub mod volume_control;
 
 use crate::now_playing::{self, NowPlaying};
+use now_playing_state::NowPlayingState;
 use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -700,7 +702,9 @@ async fn run_authenticated_client(
     let mut decoder: Option<PcmDecoder> = None;
     let mut audio_format: Option<AudioFormat> = None;
     let mut endian_locked: Option<PcmEndian> = None;
-    let mut playback_started = false;
+
+    // Folds protocol deltas into a coherent now-playing snapshot.
+    let mut np_state = NowPlayingState::new(player_id.clone(), config.player_name.clone());
 
     // Volume state — initialized from the same read used for the initial ClientState
     let mut current_volume: u8 = initial_volume;
@@ -795,7 +799,6 @@ async fn run_authenticated_client(
 
                                     decoder = None;
                                     endian_locked = None;
-                                    playback_started = false;
                                 }
                                 Message::ServerTime(server_time) => {
                                     // Update clock sync with drift tracking. t1 (client_transmitted)
@@ -810,28 +813,13 @@ async fn run_authenticated_client(
                                     clock_sync.lock().update(t1, t2, t3, t4);
                                 }
                                 Message::ServerState(state) => {
-                                    if let Some(metadata) = state.metadata {
-                                        let np = NowPlaying {
-                                            is_playing: playback_started,
-                                            track: metadata.title,
-                                            artist: metadata.artist,
-                                            album: metadata.album,
-                                            image_url: metadata.artwork_url,
-                                            player_name: Some(config.player_name.clone()),
-                                            player_id: Some(player_id.clone()),
-                                            duration: metadata.progress.as_ref().map(|p| p.track_duration as f64 / 1000.0),
-                                            elapsed: metadata.progress.as_ref().map(|p| p.track_progress as f64 / 1000.0),
-                                            can_play: !playback_started,
-                                            can_pause: playback_started,
-                                            can_next: true,
-                                            can_previous: true,
-                                        };
-                                        now_playing::update_now_playing(np);
+                                    if let Some(md) = state.metadata {
+                                        np_state.apply_metadata(&md);
+                                        now_playing::update_now_playing(np_state.snapshot());
                                     }
                                 }
                                 Message::StreamEnd(_) | Message::StreamClear(_) => {
                                     let _ = player_tx.send(PlayerCommand::Clear);
-                                    playback_started = false;
                                 }
                                 Message::ServerCommand(ServerCommand { player: Some(player_cmd) }) => {
                                     // Handle volume command
@@ -912,6 +900,10 @@ async fn run_authenticated_client(
                                         }
                                     }
                                 }
+                                Message::GroupUpdate(gu) => {
+                                    np_state.apply_group_update(&gu);
+                                    now_playing::update_now_playing(np_state.snapshot());
+                                }
                                 _ => {}
                             }
                         }
@@ -946,26 +938,6 @@ async fn run_authenticated_client(
 
                         if let (Some(ref dec), Some(ref fmt)) = (&decoder, &audio_format) {
                             if let Ok(samples) = dec.decode(audio_data) {
-                                if !playback_started {
-                                    playback_started = true;
-                                    let np = NowPlaying {
-                                        is_playing: true,
-                                        track: None,
-                                        artist: None,
-                                        album: None,
-                                        image_url: None,
-                                        player_name: Some(config.player_name.clone()),
-                                        player_id: Some(player_id.clone()),
-                                        duration: None,
-                                        elapsed: None,
-                                        can_play: false,
-                                        can_pause: true,
-                                        can_next: true,
-                                        can_previous: true,
-                                    };
-                                    now_playing::update_now_playing(np);
-                                }
-
                                 let buffer = AudioBuffer {
                                     timestamp,
                                     play_at: Instant::now(), // SyncedPlayer uses timestamp, not play_at

--- a/src-tauri/src/sendspin/now_playing_state.rs
+++ b/src-tauri/src/sendspin/now_playing_state.rs
@@ -1,0 +1,244 @@
+//! Transport-agnostic accumulator that folds Sendspin protocol messages into a
+//! [`NowPlaying`] snapshot.
+//!
+//! Two protocol facts drive the design:
+//! - `server/state` carries **merge deltas**: a progress tick re-sends
+//!   `metadata` with only `progress` set and `title`/`artist` omitted. We MERGE
+//!   (absent field = keep existing) rather than rebuilding, so progress ticks
+//!   don't wipe the track.
+//! - `group/update.playback_state` is the **only** authoritative play/stop
+//!   signal. `stream/end` arrives late mid-transition and must not touch
+//!   now-playing state.
+
+use crate::now_playing::NowPlaying;
+use sendspin::protocol::messages::{GroupUpdate, MetadataState, PlaybackState};
+
+/// Server progress fields are milliseconds; `NowPlaying` is seconds.
+const MILLIS_PER_SEC: f64 = 1000.0;
+
+/// Folds protocol messages into a coherent now-playing view.
+///
+/// `is_playing` is driven exclusively by `group/update`; metadata fields are
+/// merged from `server/state` deltas.
+pub struct NowPlayingState {
+    player_id: String,
+    player_name: String,
+    is_playing: bool,
+    title: Option<String>,
+    artist: Option<String>,
+    album: Option<String>,
+    image_url: Option<String>,
+    duration: Option<f64>,
+    elapsed: Option<f64>,
+}
+
+impl NowPlayingState {
+    pub fn new(player_id: String, player_name: String) -> Self {
+        Self {
+            player_id,
+            player_name,
+            is_playing: false,
+            title: None,
+            artist: None,
+            album: None,
+            image_url: None,
+            duration: None,
+            elapsed: None,
+        }
+    }
+
+    /// Apply a `group/update`. Only `playback_state` is authoritative for
+    /// play/stop; an update without it leaves state untouched.
+    pub fn apply_group_update(&mut self, gu: &GroupUpdate) {
+        if let Some(ps) = &gu.playback_state {
+            self.is_playing = matches!(ps, PlaybackState::Playing);
+        }
+    }
+
+    /// Merge a `server/state` metadata delta: a present field overwrites, an
+    /// absent (`None`) field keeps the existing value. serde cannot distinguish
+    /// "absent (keep)" from `"field": null` (clear); we deliberately choose
+    /// keep, since the server signals clears via `group/update: Stopped`, not
+    /// null titles.
+    pub fn apply_metadata(&mut self, md: &MetadataState) {
+        if let Some(title) = &md.title {
+            self.title = Some(title.clone());
+        }
+        if let Some(artist) = &md.artist {
+            self.artist = Some(artist.clone());
+        }
+        if let Some(album) = &md.album {
+            self.album = Some(album.clone());
+        }
+        if let Some(artwork_url) = &md.artwork_url {
+            self.image_url = Some(artwork_url.clone());
+        }
+        if let Some(p) = &md.progress {
+            self.elapsed = Some(p.track_progress as f64 / MILLIS_PER_SEC);
+            // 0 = live/unknown stream (no finite length). Represent as absent
+            // rather than a bogus zero-length track so the UI can show
+            // elapsed-only instead of a 0:00/0:00 progress bar.
+            self.duration =
+                (p.track_duration > 0).then(|| p.track_duration as f64 / MILLIS_PER_SEC);
+        }
+    }
+
+    /// Render the current accumulated state as a [`NowPlaying`] for the UI/tray.
+    pub fn snapshot(&self) -> NowPlaying {
+        NowPlaying {
+            is_playing: self.is_playing,
+            track: self.title.clone(),
+            artist: self.artist.clone(),
+            album: self.album.clone(),
+            image_url: self.image_url.clone(),
+            player_name: Some(self.player_name.clone()),
+            player_id: Some(self.player_id.clone()),
+            duration: self.duration,
+            elapsed: self.elapsed,
+            can_play: !self.is_playing,
+            can_pause: self.is_playing,
+            can_next: true,
+            can_previous: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sendspin::protocol::messages::TrackProgress;
+
+    const PLAYER_ID: &str = "player-1";
+    const PLAYER_NAME: &str = "Living Room";
+    const TITLE: &str = "100 Days, 100 Nights";
+    const ARTIST: &str = "Sharon Jones & The Dap-Kings";
+
+    fn state() -> NowPlayingState {
+        NowPlayingState::new(PLAYER_ID.to_string(), PLAYER_NAME.to_string())
+    }
+
+    /// Empty metadata delta with only `timestamp` and `progress` set.
+    fn progress_delta(progress_ms: i64, duration_ms: i64) -> MetadataState {
+        MetadataState {
+            timestamp: 0,
+            title: None,
+            artist: None,
+            album_artist: None,
+            album: None,
+            artwork_url: None,
+            year: None,
+            track: None,
+            progress: Some(TrackProgress {
+                track_progress: progress_ms,
+                track_duration: duration_ms,
+                playback_speed: 1000,
+            }),
+            repeat: None,
+            shuffle: None,
+        }
+    }
+
+    fn track_delta(title: &str, artist: &str) -> MetadataState {
+        MetadataState {
+            timestamp: 0,
+            title: Some(title.to_string()),
+            artist: Some(artist.to_string()),
+            album_artist: None,
+            album: None,
+            artwork_url: None,
+            year: None,
+            track: None,
+            progress: None,
+            repeat: None,
+            shuffle: None,
+        }
+    }
+
+    fn group_update(ps: PlaybackState) -> GroupUpdate {
+        GroupUpdate {
+            playback_state: Some(ps),
+            group_id: None,
+            group_name: None,
+        }
+    }
+
+    #[test]
+    fn progress_only_delta_keeps_track_and_updates_position() {
+        let mut s = state();
+        s.apply_metadata(&track_delta(TITLE, ARTIST));
+
+        let progress_ms = 30_000;
+        let duration_ms = 210_000;
+        s.apply_metadata(&progress_delta(progress_ms, duration_ms));
+
+        let snap = s.snapshot();
+        assert_eq!(snap.track.as_deref(), Some(TITLE));
+        assert_eq!(snap.artist.as_deref(), Some(ARTIST));
+        assert_eq!(snap.elapsed, Some(progress_ms as f64 / MILLIS_PER_SEC));
+        assert_eq!(snap.duration, Some(duration_ms as f64 / MILLIS_PER_SEC));
+    }
+
+    #[test]
+    fn live_stream_zero_duration_is_absent() {
+        let mut s = state();
+        let progress_ms = 45_000;
+        s.apply_metadata(&progress_delta(progress_ms, 0));
+
+        let snap = s.snapshot();
+        assert_eq!(snap.elapsed, Some(progress_ms as f64 / MILLIS_PER_SEC));
+        assert_eq!(
+            snap.duration, None,
+            "0 duration is live/unknown, not a zero-length track"
+        );
+    }
+
+    #[test]
+    fn group_update_drives_is_playing() {
+        let mut s = state();
+
+        s.apply_group_update(&group_update(PlaybackState::Playing));
+        let playing = s.snapshot();
+        assert!(playing.is_playing);
+        assert!(playing.can_pause);
+        assert!(!playing.can_play);
+
+        s.apply_group_update(&group_update(PlaybackState::Stopped));
+        let stopped = s.snapshot();
+        assert!(!stopped.is_playing);
+        assert!(!stopped.can_pause);
+        assert!(stopped.can_play);
+    }
+
+    #[test]
+    fn stopped_keeps_last_metadata() {
+        let mut s = state();
+        s.apply_metadata(&track_delta(TITLE, ARTIST));
+        s.apply_group_update(&group_update(PlaybackState::Playing));
+        s.apply_group_update(&group_update(PlaybackState::Stopped));
+
+        let snap = s.snapshot();
+        assert!(!snap.is_playing);
+        assert_eq!(snap.track.as_deref(), Some(TITLE), "track survives stop");
+        assert_eq!(snap.artist.as_deref(), Some(ARTIST));
+    }
+
+    #[test]
+    fn metadata_delta_while_stopped_does_not_resume() {
+        let mut s = state();
+        s.apply_group_update(&group_update(PlaybackState::Stopped));
+        s.apply_metadata(&track_delta(TITLE, ARTIST));
+
+        let snap = s.snapshot();
+        assert!(!snap.is_playing, "metadata must not flip play state");
+        assert_eq!(snap.track.as_deref(), Some(TITLE));
+    }
+
+    #[test]
+    fn snapshot_carries_player_identity() {
+        let snap = state().snapshot();
+        assert_eq!(snap.player_id.as_deref(), Some(PLAYER_ID));
+        assert_eq!(snap.player_name.as_deref(), Some(PLAYER_NAME));
+        assert!(snap.can_next);
+        assert!(snap.can_previous);
+    }
+}


### PR DESCRIPTION
The native Sendspin now-playing was unreliable for two reasons. First, `is_playing` was derived from frame-counting and `stream/end`, but the MA server emits `stream/end` late mid-transition (after the next track is already playing), clobbering active playback into a stuck "Not Playing". Second, `server/state` is a merge-delta protocol, but the loop rebuilt `NowPlaying` from scratch each message, so progress ticks (which omit title/artist) wiped the track.

Introduce `NowPlayingState`, a pure, unit-tested accumulator that folds protocol messages into a `NowPlaying`: `is_playing` is driven solely by `group/update.playback_state` (now handled), and metadata is merged (absent field = keep existing). Live/unknown streams (duration 0) now map to `None` rather than a bogus zero-length track. Stream-control messages are reduced to audio-pipeline duties only, and the now-dead `playback_started` flag is removed.