### PR TITLE
chore(ci): bump checkout and setup-node to v6 (Node 24)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get version from tag
         id: version
@@ -98,7 +98,7 @@ jobs:
             xdg-utils
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "lts/*"
           cache: "yarn"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "lts/*"
           cache: "yarn"


### PR DESCRIPTION
actions/checkout@v4 and actions/setup-node@v4 run on Node.js 20, which GitHub force-migrates to Node 24 on 2026-06-16 and removes on 2026-09-16, producing deprecation warnings on every run. Bump both to @v6 in the release and test workflows.

setup-node@v6 limits automatic caching to npm, but we pass cache: "yarn" explicitly, which remains supported, so yarn caching is unaffected.