### PR TITLE
fix: retain previous log on rotation (KeepSome(2))

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -612,7 +612,7 @@ pub fn run() {
                     file_name: Some(LOG_FILE_STEM.to_string()),
                 })])
                 .max_file_size(5 * 1024 * 1024) // 5MB
-                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(2))
                 .level(log::LevelFilter::Info);
             if cfg!(debug_assertions) {
                 log_builder = log_builder.target(Target::new(TargetKind::Stdout));


### PR DESCRIPTION
The file logging added in #66 used RotationStrategy::KeepOne, which hard-deletes logs.log on rotation. Since rotation runs at app launch, a restart to recover from a connection issue would wipe the very log needed to debug it. Switch to KeepSome(2): disk stays bounded (~10MB, two 5MB files) while the previous session's log survives for post-mortems.