### PR TITLE
feat(media-controls): native macOS backend via objc2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
  "clipboard-win",
  "image",
  "log",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -397,7 +397,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -860,7 +860,7 @@ dependencies = [
  "ndk-context",
  "num-derive",
  "num-traits",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-audio-toolbox",
  "objc2-avf-audio",
  "objc2-core-audio",
@@ -1203,7 +1203,7 @@ dependencies = [
  "bitflags 2.10.0",
  "block2 0.6.2",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2790,7 +2790,7 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -2805,6 +2805,7 @@ dependencies = [
 name = "music-assistant"
 version = "0.1.0"
 dependencies = [
+ "block2 0.6.2",
  "coreaudio-sys",
  "cpal",
  "dirs 5.0.1",
@@ -2815,6 +2816,11 @@ dependencies = [
  "libpulse-binding",
  "log",
  "mdns-sd",
+ "objc2 0.6.4",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-media-player",
  "parking_lot",
  "png 0.17.16",
  "raw-window-handle",
@@ -2834,6 +2840,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tokio",
  "tokio-tungstenite 0.26.2",
+ "ureq",
  "uuid 1.19.0",
  "windows 0.58.0",
  "windows-core 0.58.0",
@@ -3023,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
  "objc2-exception-helper",
@@ -3040,7 +3047,7 @@ dependencies = [
  "bitflags 2.10.0",
  "block2 0.6.2",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-foundation",
@@ -3060,10 +3067,21 @@ checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3073,7 +3091,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3084,7 +3102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.10.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3095,7 +3113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
 dependencies = [
  "dispatch2",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -3108,7 +3126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
  "bitflags 2.10.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -3118,7 +3136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
  "bitflags 2.10.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3132,7 +3150,7 @@ dependencies = [
  "block2 0.6.2",
  "dispatch2",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -3143,7 +3161,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.10.0",
  "dispatch2",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -3154,7 +3172,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3165,7 +3183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.10.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -3177,7 +3195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
  "bitflags 2.10.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-io-surface",
@@ -3219,7 +3237,7 @@ dependencies = [
  "bitflags 2.10.0",
  "block2 0.6.2",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3230,7 +3248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.10.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3240,8 +3258,23 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-media-player"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f2a98483f6e76313cb85a5a185eaa3cda86a177b13a8852d56cbd0085bf635"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-app-kit",
+ "objc2-av-foundation",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3263,7 +3296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
 dependencies = [
  "bitflags 2.10.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-foundation 0.3.2",
 ]
@@ -3288,7 +3321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.10.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3299,7 +3332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
  "bitflags 2.10.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3310,7 +3343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.10.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
@@ -3323,7 +3356,7 @@ checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.10.0",
  "block2 0.6.2",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -3425,7 +3458,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
  "objc2-osa-kit",
  "serde",
@@ -4225,7 +4258,7 @@ dependencies = [
  "gtk-sys",
  "js-sys",
  "log",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -4329,6 +4362,7 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4998,7 +5032,7 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-foundation 0.3.2",
  "once_cell",
@@ -5070,7 +5104,7 @@ dependencies = [
  "log",
  "mime",
  "muda",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-foundation 0.3.2",
  "objc2-ui-kit",
@@ -5258,7 +5292,7 @@ dependencies = [
  "byte-unit",
  "fern",
  "log",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
  "serde",
  "serde_json",
@@ -5365,7 +5399,7 @@ dependencies = [
  "gtk",
  "http",
  "jni",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-ui-kit",
  "objc2-web-kit",
  "raw-window-handle",
@@ -5389,7 +5423,7 @@ dependencies = [
  "http",
  "jni",
  "log",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-foundation 0.3.2",
  "once_cell",
@@ -5860,7 +5894,7 @@ dependencies = [
  "dirs 6.0.0",
  "libappindicator",
  "muda",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -6028,6 +6062,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6062,6 +6125,12 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6467,7 +6536,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -7092,7 +7161,7 @@ dependencies = [
  "kuchikiki",
  "libc",
  "ndk",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "music-assistant"
 repository = "https://github.com/music-assistant/desktop-app"
-rust-version = "1.77.2"
+rust-version = "1.85"
 version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -43,7 +43,10 @@ tokio = { version = "1", features = ["sync", "macros", "time"] }
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 uuid = { version = "1", features = ["v4"] }
 
-# System media controls (Now Playing integration)
+# System media controls (Now Playing integration).
+# macOS uses the native objc2 backend (src/media_controls/macos.rs); souvlaki
+# remains for Windows/Linux until their native backends land.
+[target.'cfg(not(target_os = "macos"))'.dependencies]
 souvlaki = "0.8"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
@@ -63,7 +66,14 @@ windows = { version = "0.58", features = [
 windows-core = "0.58"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6.2"
 coreaudio-sys = "0.2"
+objc2 = "0.6.4"
+objc2-app-kit = "0.3.2"
+objc2-core-foundation = "0.3.2"
+objc2-foundation = "0.3.2"
+objc2-media-player = "0.3.2"
+ureq = "3.2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libpulse-binding = "2.28"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,6 +252,18 @@ fn start_services(app_handle: tauri::AppHandle) {
         #[cfg(not(target_os = "windows"))]
         let hwnd = None;
 
+        // Dispatcher onto the NSApplication main run loop. Used by the macOS
+        // media-controls backend (objc2 calls must run there); ignored by the
+        // souvlaki backend on other platforms.
+        let dispatch: media_controls::MainThreadDispatch = {
+            let app = APP_HANDLE.lock().unwrap().clone();
+            Arc::new(move |f| {
+                if let Some(ref app) = app {
+                    let _ = app.run_on_main_thread(f);
+                }
+            })
+        };
+
         // Initialize media controls with callback for control events
         media_controls::init(Arc::new(|command| {
             // Route media control events to frontend
@@ -270,7 +282,7 @@ fn start_services(app_handle: tauri::AppHandle) {
                     ));
                 }
             }
-        }), hwnd);
+        }), hwnd, dispatch);
 
         // Start Discord RPC in a separate thread
         thread::spawn(|| {

--- a/src-tauri/src/media_controls/macos.rs
+++ b/src-tauri/src/media_controls/macos.rs
@@ -1,0 +1,245 @@
+//! Native macOS media-controls backend: drives `MPNowPlayingInfoCenter` and
+//! `MPRemoteCommandCenter` directly via objc2, replacing the `souvlaki` crate
+//! that crashed the app on unloadable cover URLs.
+//!
+//! Every objc2 call must run on the `NSApplication` main run loop, reached via
+//! the [`MainThreadDispatch`](super::MainThreadDispatch) given to [`init`];
+//! `AppKit` delivers remote-command handlers there too. Nothing objc2 is kept in
+//! a static (those types are `!Send`) — only plain data is, and the framework
+//! singletons are re-fetched inside each main-thread closure.
+#![allow(unsafe_code)] // objc2 framework methods are all `unsafe`; lift the workspace deny.
+
+use super::{MainThreadDispatch, MediaControlCallback, NowPlayingPlan, PlaybackState};
+use crate::now_playing::NowPlaying;
+use block2::RcBlock;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, ProtocolObject};
+use objc2::AnyThread;
+use objc2_app_kit::NSImage;
+use objc2_core_foundation::CGSize;
+use objc2_foundation::{NSCopying, NSData, NSMutableDictionary, NSNumber, NSString};
+use objc2_media_player::{
+    MPMediaItemArtwork, MPMediaItemPropertyAlbumTitle, MPMediaItemPropertyArtist,
+    MPMediaItemPropertyArtwork, MPMediaItemPropertyPlaybackDuration, MPMediaItemPropertyTitle,
+    MPNowPlayingInfoCenter, MPNowPlayingInfoPropertyElapsedPlaybackTime,
+    MPNowPlayingInfoPropertyPlaybackRate, MPRemoteCommand, MPRemoteCommandCenter,
+    MPRemoteCommandEvent, MPRemoteCommandHandlerStatus,
+};
+use parking_lot::Mutex;
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+const ARTWORK_SIZE: f64 = 512.0;
+const COVER_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_COVER_BYTES: u64 = 8 * 1024 * 1024;
+
+static CALLBACK: Mutex<Option<MediaControlCallback>> = Mutex::new(None);
+static DISPATCH: Mutex<Option<MainThreadDispatch>> = Mutex::new(None);
+static LAST_PLAN: Mutex<Option<NowPlayingPlan>> = Mutex::new(None);
+static COVER: Mutex<CoverCache> = Mutex::new(CoverCache::EMPTY);
+/// Invalidates any in-flight cover download when the track changes.
+static COVER_GEN: AtomicU64 = AtomicU64::new(0);
+static COMMANDS_REGISTERED: AtomicBool = AtomicBool::new(false);
+
+/// Cover bytes (not an objc2 object) so the cache stays `Send`.
+struct CoverCache {
+    url: Option<String>,
+    bytes: Option<Arc<Vec<u8>>>,
+}
+
+impl CoverCache {
+    const EMPTY: Self = Self {
+        url: None,
+        bytes: None,
+    };
+}
+
+pub fn init(callback: MediaControlCallback, dispatch: MainThreadDispatch) {
+    *CALLBACK.lock() = Some(callback);
+    *DISPATCH.lock() = Some(dispatch.clone());
+
+    if COMMANDS_REGISTERED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    dispatch(Box::new(|| unsafe { register_commands() }));
+}
+
+pub fn update(np: &NowPlaying) {
+    let plan = super::plan(np);
+    refresh_cover_if_changed(&plan);
+    *LAST_PLAN.lock() = Some(plan);
+    dispatch_render();
+}
+
+pub fn clear() {
+    *LAST_PLAN.lock() = None;
+    COVER_GEN.fetch_add(1, Ordering::SeqCst);
+    *COVER.lock() = CoverCache::EMPTY;
+    let Some(dispatch) = DISPATCH.lock().clone() else {
+        return;
+    };
+    dispatch(Box::new(|| unsafe {
+        MPNowPlayingInfoCenter::defaultCenter().setNowPlayingInfo(None);
+    }));
+}
+
+fn refresh_cover_if_changed(plan: &NowPlayingPlan) {
+    let want = plan.image_url.clone();
+    if COVER.lock().url == want {
+        return;
+    }
+
+    let generation = COVER_GEN.fetch_add(1, Ordering::SeqCst) + 1;
+    {
+        let mut cover = COVER.lock();
+        cover.url.clone_from(&want);
+        // Drop the old art now so the new track never shows the previous cover.
+        cover.bytes = None;
+    }
+
+    let Some(url) = want else {
+        return;
+    };
+
+    std::thread::spawn(move || match download_image(&url) {
+        Ok(bytes) => {
+            if COVER_GEN.load(Ordering::SeqCst) != generation {
+                return; // Superseded by a newer track.
+            }
+            {
+                let mut cover = COVER.lock();
+                if cover.url.as_deref() != Some(url.as_str()) {
+                    return;
+                }
+                cover.bytes = Some(Arc::new(bytes));
+            }
+            dispatch_render();
+        }
+        Err(e) => log::warn!("[MediaControls] cover download failed for {url}: {e}"),
+    });
+}
+
+fn download_image(url: &str) -> Result<Vec<u8>, ureq::Error> {
+    let config = ureq::Agent::config_builder()
+        .timeout_global(Some(COVER_TIMEOUT))
+        .build();
+    let agent = ureq::Agent::new_with_config(config);
+    let mut response = agent.get(url).call()?;
+    let bytes = response
+        .body_mut()
+        .with_config()
+        .limit(MAX_COVER_BYTES)
+        .read_to_vec()?;
+    Ok(bytes)
+}
+
+fn dispatch_render() {
+    let Some(dispatch) = DISPATCH.lock().clone() else {
+        return;
+    };
+    dispatch(Box::new(|| unsafe { render() }));
+}
+
+unsafe fn render() {
+    let Some(plan) = LAST_PLAN.lock().clone() else {
+        return;
+    };
+    let center = MPNowPlayingInfoCenter::defaultCenter();
+    if plan.state == PlaybackState::Stopped {
+        center.setNowPlayingInfo(None);
+        return;
+    }
+    let info = build_info_dict(&plan);
+    center.setNowPlayingInfo(Some(&info));
+}
+
+unsafe fn build_info_dict(
+    plan: &NowPlayingPlan,
+) -> Retained<NSMutableDictionary<NSString, AnyObject>> {
+    let dict = NSMutableDictionary::<NSString, AnyObject>::new();
+
+    if let Some(title) = &plan.title {
+        set_string(&dict, MPMediaItemPropertyTitle, title);
+    }
+    if let Some(artist) = &plan.artist {
+        set_string(&dict, MPMediaItemPropertyArtist, artist);
+    }
+    if let Some(album) = &plan.album {
+        set_string(&dict, MPMediaItemPropertyAlbumTitle, album);
+    }
+    if let Some(duration) = plan.duration_secs {
+        set_number(&dict, MPMediaItemPropertyPlaybackDuration, duration);
+    }
+    if let Some(elapsed) = plan.elapsed_secs {
+        set_number(&dict, MPNowPlayingInfoPropertyElapsedPlaybackTime, elapsed);
+    }
+    set_number(&dict, MPNowPlayingInfoPropertyPlaybackRate, plan.rate);
+
+    if let Some(bytes) = COVER.lock().bytes.clone() {
+        let artwork = make_artwork(bytes);
+        dict.setObject_forKey(&artwork, copying_key(MPMediaItemPropertyArtwork));
+    }
+
+    dict
+}
+
+unsafe fn set_string(dict: &NSMutableDictionary<NSString, AnyObject>, key: &NSString, value: &str) {
+    let value = NSString::from_str(value);
+    dict.setObject_forKey(&value, copying_key(key));
+}
+
+unsafe fn set_number(dict: &NSMutableDictionary<NSString, AnyObject>, key: &NSString, value: f64) {
+    let number = NSNumber::numberWithDouble(value);
+    dict.setObject_forKey(&number, copying_key(key));
+}
+
+fn copying_key(key: &NSString) -> &ProtocolObject<dyn NSCopying> {
+    ProtocolObject::from_ref(key)
+}
+
+/// `AppKit` may invoke the request handler on any thread, so it touches only the
+/// thread-safe `NSData`/`NSImage` constructors and returns the image autoreleased
+/// (`+0`) via [`Retained::autorelease_return`], as the handler's contract expects.
+unsafe fn make_artwork(bytes: Arc<Vec<u8>>) -> Retained<MPMediaItemArtwork> {
+    let bounds = CGSize {
+        width: ARTWORK_SIZE,
+        height: ARTWORK_SIZE,
+    };
+    let handler = RcBlock::new(move |_size: CGSize| -> NonNull<NSImage> {
+        let data = NSData::with_bytes(&bytes);
+        let image = match NSImage::initWithData(NSImage::alloc(), &data) {
+            Some(image) => image,
+            None => NSImage::new(),
+        };
+        NonNull::new(Retained::autorelease_return(image))
+            .expect("autoreleased NSImage pointer is non-null")
+    });
+    MPMediaItemArtwork::initWithBoundsSize_requestHandler(
+        MPMediaItemArtwork::alloc(),
+        bounds,
+        &handler,
+    )
+}
+
+unsafe fn register_commands() {
+    let center = MPRemoteCommandCenter::sharedCommandCenter();
+    add_handler(&center.playCommand(), "play");
+    add_handler(&center.pauseCommand(), "pause");
+    add_handler(&center.togglePlayPauseCommand(), "toggle");
+    add_handler(&center.nextTrackCommand(), "next");
+    add_handler(&center.previousTrackCommand(), "previous");
+    add_handler(&center.stopCommand(), "stop");
+}
+
+unsafe fn add_handler(command: &MPRemoteCommand, action: &'static str) {
+    command.setEnabled(true);
+    let handler = RcBlock::new(move |_event: NonNull<MPRemoteCommandEvent>| {
+        if let Some(callback) = CALLBACK.lock().clone() {
+            callback(action);
+        }
+        MPRemoteCommandHandlerStatus::Success
+    });
+    let _target = command.addTargetWithHandler(&handler);
+}

--- a/src-tauri/src/media_controls/mod.rs
+++ b/src-tauri/src/media_controls/mod.rs
@@ -1,0 +1,182 @@
+//! System media controls integration.
+//!
+//! Routes to a per-platform backend selected at compile time:
+//! - macOS: native objc2 backend (`MPNowPlayingInfoCenter` + `MPRemoteCommandCenter`)
+//! - Windows / Linux: souvlaki (pending their own native backends)
+//!
+//! Each backend exposes the same `init` / `update` / `clear` free functions;
+//! the module system enforces that contract at compile time, so no runtime
+//! trait object is needed (only one backend is ever compiled in).
+
+use crate::now_playing::NowPlaying;
+use std::sync::Arc;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(not(target_os = "macos"))]
+mod souvlaki_backend;
+
+/// Callback type for media control events (`"play"`, `"pause"`, `"toggle"`,
+/// `"next"`, `"previous"`, `"stop"`).
+pub type MediaControlCallback = Arc<dyn Fn(&str) + Send + Sync>;
+
+/// Runs a closure on the platform UI / main thread.
+///
+/// Required by the macOS backend: `MPRemoteCommandCenter` registration, its
+/// handler blocks, and `MPNowPlayingInfoCenter` updates must occur on the
+/// `NSApplication` main run loop. Other backends ignore it.
+pub type MainThreadDispatch = Arc<dyn Fn(Box<dyn FnOnce() + Send + 'static>) + Send + Sync>;
+
+/// `hwnd` is used only on Windows; `dispatch` is used only on macOS.
+#[allow(unused_variables)]
+pub fn init(
+    callback: MediaControlCallback,
+    hwnd: Option<*mut std::ffi::c_void>,
+    dispatch: MainThreadDispatch,
+) {
+    #[cfg(target_os = "macos")]
+    macos::init(callback, dispatch);
+    #[cfg(not(target_os = "macos"))]
+    souvlaki_backend::init(callback, hwnd);
+}
+
+#[allow(unused_variables)]
+pub fn update(np: &NowPlaying) {
+    #[cfg(target_os = "macos")]
+    macos::update(np);
+    #[cfg(not(target_os = "macos"))]
+    souvlaki_backend::update(np);
+}
+
+#[allow(dead_code)]
+pub fn clear() {
+    #[cfg(target_os = "macos")]
+    macos::clear();
+    #[cfg(not(target_os = "macos"))]
+    souvlaki_backend::clear();
+}
+
+// ---------------------------------------------------------------------------
+// Platform-agnostic mapping core
+//
+// Pure translation from `NowPlaying` into a backend-neutral plan. Kept free of
+// any FFI so it is fully unit-testable; the native backends are thin imperative
+// shells that render this plan. Compiled where a consumer exists (macOS) or for
+// tests on any host.
+// ---------------------------------------------------------------------------
+
+/// `MPNowPlayingInfoPropertyPlaybackRate` value while playing.
+#[cfg(any(target_os = "macos", test))]
+pub(crate) const PLAYBACK_RATE_PLAYING: f64 = 1.0;
+/// `MPNowPlayingInfoPropertyPlaybackRate` value while paused or stopped.
+#[cfg(any(target_os = "macos", test))]
+pub(crate) const PLAYBACK_RATE_STOPPED: f64 = 0.0;
+
+/// Coarse playback state the OS distinguishes.
+#[cfg(any(target_os = "macos", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlaybackState {
+    Playing,
+    Paused,
+    Stopped,
+}
+
+/// Backend-neutral description of what the OS now-playing surface should show.
+#[cfg(any(target_os = "macos", test))]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct NowPlayingPlan {
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub duration_secs: Option<f64>,
+    pub elapsed_secs: Option<f64>,
+    pub state: PlaybackState,
+    pub rate: f64,
+    pub image_url: Option<String>,
+}
+
+#[cfg(any(target_os = "macos", test))]
+pub(crate) fn plan(np: &NowPlaying) -> NowPlayingPlan {
+    let state = if np.is_playing {
+        PlaybackState::Playing
+    } else if np.track.is_some() {
+        PlaybackState::Paused
+    } else {
+        PlaybackState::Stopped
+    };
+    let rate = match state {
+        PlaybackState::Playing => PLAYBACK_RATE_PLAYING,
+        PlaybackState::Paused | PlaybackState::Stopped => PLAYBACK_RATE_STOPPED,
+    };
+    NowPlayingPlan {
+        title: np.track.clone(),
+        artist: np.artist.clone(),
+        album: np.album.clone(),
+        duration_secs: np.duration,
+        elapsed_secs: np.elapsed,
+        state,
+        rate,
+        image_url: np.image_url.clone(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)] // exact comparisons against the rate constants
+mod tests {
+    use super::*;
+
+    fn np(is_playing: bool, track: Option<&str>) -> NowPlaying {
+        NowPlaying {
+            is_playing,
+            track: track.map(str::to_owned),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn playing_with_track_reports_playing_rate() {
+        let p = plan(&np(true, Some("Song")));
+        assert_eq!(p.state, PlaybackState::Playing);
+        assert_eq!(p.rate, PLAYBACK_RATE_PLAYING);
+    }
+
+    #[test]
+    fn paused_when_not_playing_but_track_present() {
+        let p = plan(&np(false, Some("Song")));
+        assert_eq!(p.state, PlaybackState::Paused);
+        assert_eq!(p.rate, PLAYBACK_RATE_STOPPED);
+    }
+
+    #[test]
+    fn stopped_without_track() {
+        let p = plan(&np(false, None));
+        assert_eq!(p.state, PlaybackState::Stopped);
+        assert_eq!(p.rate, PLAYBACK_RATE_STOPPED);
+        assert!(p.title.is_none());
+    }
+
+    #[test]
+    fn playing_flag_without_track_still_playing() {
+        // Upstream filters this case, but the mapping must stay self-consistent.
+        let p = plan(&np(true, None));
+        assert_eq!(p.state, PlaybackState::Playing);
+        assert_eq!(p.rate, PLAYBACK_RATE_PLAYING);
+    }
+
+    #[test]
+    fn maps_metadata_and_timing_fields() {
+        let mut n = np(true, Some("Song"));
+        n.artist = Some("Artist".to_owned());
+        n.album = Some("Album".to_owned());
+        n.duration = Some(200.0);
+        n.elapsed = Some(5.0);
+        n.image_url = Some("http://host/cover.jpg".to_owned());
+
+        let p = plan(&n);
+        assert_eq!(p.artist.as_deref(), Some("Artist"));
+        assert_eq!(p.album.as_deref(), Some("Album"));
+        assert_eq!(p.duration_secs, Some(200.0));
+        assert_eq!(p.elapsed_secs, Some(5.0));
+        assert_eq!(p.image_url.as_deref(), Some("http://host/cover.jpg"));
+    }
+}

--- a/src-tauri/src/media_controls/souvlaki_backend.rs
+++ b/src-tauri/src/media_controls/souvlaki_backend.rs
@@ -1,42 +1,33 @@
-//! System media controls integration
+//! souvlaki-backed media controls (Windows + Linux).
 //!
-//! This module provides integration with the OS media controls:
-//! - macOS: Now Playing in Control Center, media keys
+//! Provides:
 //! - Windows: System Media Transport Controls
 //! - Linux: MPRIS D-Bus interface
 //!
-//! Uses the souvlaki crate for cross-platform support.
+//! Retained behind `cfg(not(target_os = "macos"))` until the remaining
+//! per-platform native backends land. macOS uses the native objc2 backend.
 
+use super::MediaControlCallback;
 use crate::now_playing::NowPlaying;
 use parking_lot::Mutex;
 use souvlaki::{
     MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, MediaPosition, PlatformConfig,
 };
-use std::sync::Arc;
 use std::time::Duration;
 
-/// Callback type for media control events
-pub type MediaControlCallback = Arc<dyn Fn(&str) + Send + Sync>;
-
-/// Global media controls instance
 static MEDIA_CONTROLS: Mutex<Option<MediaControls>> = Mutex::new(None);
-
-/// Callback for media control events
 static EVENT_CALLBACK: Mutex<Option<MediaControlCallback>> = Mutex::new(None);
 
-/// Initialize media controls
 #[allow(unused_variables)]
 pub fn init(callback: MediaControlCallback, hwnd_param: Option<*mut std::ffi::c_void>) {
-    // Store the callback
     {
         let mut cb = EVENT_CALLBACK.lock();
         *cb = Some(callback);
     }
 
-    // Platform-specific configuration
     #[cfg(target_os = "windows")]
     let hwnd = {
-        // On Windows, MediaControls requires a valid HWND
+        // SMTC requires a valid HWND to anchor the controls.
         if hwnd_param.is_none() {
             log::error!("[MediaControls] Disabled on Windows (no HWND available)");
             return;
@@ -55,13 +46,11 @@ pub fn init(callback: MediaControlCallback, hwnd_param: Option<*mut std::ffi::c_
 
     match MediaControls::new(config) {
         Ok(mut controls) => {
-            // Attach event handler
             if let Err(e) = controls.attach(handle_media_event) {
                 log::error!("[MediaControls] Failed to attach event handler: {:?}", e);
                 return;
             }
 
-            // Store the controls
             let mut mc = MEDIA_CONTROLS.lock();
             *mc = Some(controls);
         }
@@ -71,7 +60,6 @@ pub fn init(callback: MediaControlCallback, hwnd_param: Option<*mut std::ffi::c_
     }
 }
 
-/// Handle media control events from the OS
 fn handle_media_event(event: MediaControlEvent) {
     let command = match event {
         MediaControlEvent::Play => "play",
@@ -88,35 +76,17 @@ fn handle_media_event(event: MediaControlEvent) {
     }
 }
 
-/// Determine the playback state category from now-playing info
-#[cfg(test)]
-fn determine_playback_state(is_playing: bool, has_track: bool) -> &'static str {
-    if is_playing {
-        "playing"
-    } else if has_track {
-        "paused"
-    } else {
-        "stopped"
-    }
-}
-
-/// Update media controls with now-playing info
 pub fn update(np: &NowPlaying) {
     let mut controls = MEDIA_CONTROLS.lock();
     let Some(ref mut controls) = *controls else {
         return;
     };
 
-    // Metadata must be set before playback: on macOS, set_metadata replaces the
-    // now-playing dictionary, which would wipe the elapsed position that
-    // set_playback merges in. The Windows and MPRIS backends write disjoint
-    // fields and are order-agnostic.
     if np.track.is_some() || np.artist.is_some() {
         let metadata = MediaMetadata {
             title: np.track.as_deref(),
             artist: np.artist.as_deref(),
             album: np.album.as_deref(),
-            // Cover URL - souvlaki supports URLs on some platforms
             cover_url: np.image_url.as_deref(),
             duration: np.duration.map(Duration::from_secs_f64),
         };
@@ -126,13 +96,8 @@ pub fn update(np: &NowPlaying) {
         }
     }
 
-    // Report the real elapsed position so the OS scrubber tracks playback.
-    // The OS extrapolates between our ~1/sec updates.
-    //
-    // NOTE: on macOS this is necessary but not sufficient to render the Control
-    // Center scrubber, which also requires MPNowPlayingInfoPropertyPlaybackRate
-    // (1.0 playing / 0.0 paused) — a key souvlaki never sets. Revisit when we
-    // replace souvlaki: https://github.com/music-assistant/desktop-app/issues/59
+    // Report elapsed position so the OS scrubber can extrapolate between our
+    // ~1/sec updates.
     let progress = np
         .elapsed
         .map(|secs| MediaPosition(Duration::from_secs_f64(secs)));
@@ -149,24 +114,10 @@ pub fn update(np: &NowPlaying) {
     }
 }
 
-/// Clear media controls (when stopping playback or disconnecting)
 #[allow(dead_code)]
 pub fn clear() {
     let mut controls = MEDIA_CONTROLS.lock();
     if let Some(ref mut controls) = *controls {
         let _ = controls.set_playback(MediaPlayback::Stopped);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_determine_playback_state() {
-        assert_eq!(determine_playback_state(true, true), "playing");
-        assert_eq!(determine_playback_state(true, false), "playing");
-        assert_eq!(determine_playback_state(false, true), "paused");
-        assert_eq!(determine_playback_state(false, false), "stopped");
     }
 }

--- a/src-tauri/src/sendspin/volume_control/macos.rs
+++ b/src-tauri/src/sendspin/volume_control/macos.rs
@@ -54,10 +54,10 @@ impl MacOSVolumeControl {
 
             let status = AudioObjectGetPropertyData(
                 kAudioObjectSystemObject,
-                &property_address,
+                &raw const property_address,
                 0,
                 ptr::null(),
-                &mut size,
+                &raw mut size,
                 std::ptr::addr_of_mut!(device_id).cast(),
             );
 
@@ -80,7 +80,7 @@ impl MacOSVolumeControl {
                 mElement: kAudioObjectPropertyElementMain,
             };
 
-            AudioObjectHasProperty(device_id, &property_address) != 0
+            AudioObjectHasProperty(device_id, &raw const property_address) != 0
         };
 
         if !has_volume {
@@ -106,7 +106,7 @@ impl MacOSVolumeControl {
 
             let status = AudioObjectSetPropertyData(
                 self.device_id,
-                &property_address,
+                &raw const property_address,
                 0,
                 ptr::null(),
                 mem::size_of::<f32>() as u32,
@@ -134,10 +134,10 @@ impl MacOSVolumeControl {
 
             let status = AudioObjectGetPropertyData(
                 self.device_id,
-                &property_address,
+                &raw const property_address,
                 0,
                 ptr::null(),
-                &mut size,
+                &raw mut size,
                 std::ptr::addr_of_mut!(volume).cast(),
             );
 
@@ -179,7 +179,7 @@ impl VolumeControlImpl for MacOSVolumeControl {
             };
 
             // Check if device supports mute
-            if AudioObjectHasProperty(self.device_id, &property_address) == 0 {
+            if AudioObjectHasProperty(self.device_id, &raw const property_address) == 0 {
                 return Err("Device does not support mute".to_string());
             }
 
@@ -187,7 +187,7 @@ impl VolumeControlImpl for MacOSVolumeControl {
 
             let status = AudioObjectSetPropertyData(
                 self.device_id,
-                &property_address,
+                &raw const property_address,
                 0,
                 ptr::null(),
                 mem::size_of::<u32>() as u32,
@@ -216,7 +216,7 @@ impl VolumeControlImpl for MacOSVolumeControl {
             };
 
             // Check if device supports mute
-            if AudioObjectHasProperty(self.device_id, &property_address) == 0 {
+            if AudioObjectHasProperty(self.device_id, &raw const property_address) == 0 {
                 return Ok(false); // Device doesn't support mute, treat as unmuted
             }
 
@@ -225,10 +225,10 @@ impl VolumeControlImpl for MacOSVolumeControl {
 
             let status = AudioObjectGetPropertyData(
                 self.device_id,
-                &property_address,
+                &raw const property_address,
                 0,
                 ptr::null(),
-                &mut size,
+                &raw mut size,
                 std::ptr::addr_of_mut!(mute_value).cast(),
             );
 
@@ -304,10 +304,10 @@ impl VolumeControlImpl for MacOSVolumeControl {
 
                     let status = AudioObjectGetPropertyData(
                         device_id,
-                        &property_address,
+                        &raw const property_address,
                         0,
                         ptr::null(),
-                        &mut size,
+                        &raw mut size,
                         std::ptr::addr_of_mut!(volume).cast(),
                     );
 
@@ -326,16 +326,16 @@ impl VolumeControlImpl for MacOSVolumeControl {
                         mElement: kAudioObjectPropertyElementMain,
                     };
 
-                    if AudioObjectHasProperty(device_id, &property_address) != 0 {
+                    if AudioObjectHasProperty(device_id, &raw const property_address) != 0 {
                         let mut mute_value: u32 = 0;
                         let mut size = mem::size_of::<u32>() as u32;
 
                         let status = AudioObjectGetPropertyData(
                             device_id,
-                            &property_address,
+                            &raw const property_address,
                             0,
                             ptr::null(),
-                            &mut size,
+                            &raw mut size,
                             std::ptr::addr_of_mut!(mute_value).cast(),
                         );
 


### PR DESCRIPTION
This is step one of https://github.com/music-assistant/desktop-app/issues/59, which I'll be doing in stages. First up macOS because it's my primary desktop and I was able to test it directly. Calling it an enhancement as it directly fixes a known crashing bug with Souvlaki on macOS (by removing Souvlaki).

Replace souvlaki on macOS with a direct objc2 backend driving MPNowPlayingInfoCenter and MPRemoteCommandCenter. Cover art is downloaded as bytes and handed to MPMediaItemArtwork (never a URL), eliminating the nil-image FFI crash. A main-thread dispatcher runs objc2 calls on the NSApplication run loop, and playback rate is reported so the Control Center scrubber tracks. souvlaki is now confined to Windows/Linux.

 Media controls split into a per-platform module (mod.rs routing, macos.rs, souvlaki_backend.rs) over a unit-tested pure mapping core. MSRV raised to 1.85 (ureq).