### PR TITLE
fix: Server connection preflight

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ png = "0.17"
 sendspin = { git = "https://github.com/Sendspin/sendspin-rs", tag = "v0.2.0" }
 tokio = { version = "1", features = ["sync", "macros", "time"] }
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
+ureq = "3.2.1"
 uuid = { version = "1", features = ["v4"] }
 
 # System media controls (Now Playing integration).
@@ -74,7 +75,6 @@ objc2-app-kit = "0.3.2"
 objc2-core-foundation = "0.3.2"
 objc2-foundation = "0.3.2"
 objc2-media-player = "0.3.2"
-ureq = "3.2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libpulse-binding = "2.28"

--- a/src-tauri/resources/index.html
+++ b/src-tauri/resources/index.html
@@ -476,11 +476,7 @@
     <script src="i18n.js"></script>
     <script>
       let autoConnectAttempted = false;
-      let connectController = null;
-      // Hard cap on how long we wait for a server to respond before treating the
-      // connection as failed, so a bad address can never hang the launcher.
-      const CONNECT_TIMEOUT_MS = 5000;
-
+      let connectAttemptId = 0;
       // Detect dark mode
       if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
         document.documentElement.classList.add("dark");
@@ -545,12 +541,14 @@
         return await connectToServer(lastServer.url, lastServer.name, { silent: true });
       }
 
-      // Cancel auto-connect and show launcher
+      function isStaleConnectAttempt(attemptId) {
+        return attemptId !== connectAttemptId;
+      }
+
+      // Cancel auto-connect and show launcher. Native reachability checks cannot be
+      // aborted from JavaScript, so bump the attempt id and ignore stale results.
       function cancelAutoConnect() {
-        if (connectController) {
-          connectController.abort();
-          connectController = null;
-        }
+        connectAttemptId += 1;
         document.getElementById("connectingOverlay").classList.add("hidden");
         document.getElementById("launcher").classList.remove("hidden");
         loadLastServer();
@@ -655,25 +653,9 @@
       // Verify a server actually responds before we commit a full-page navigation.
       // A bare window.location.href to an unreachable host (e.g. https:// against a
       // plain-http port) hangs the webview forever with no error, so we preflight
-      // with a hard timeout. Rejects on network error, timeout, or user cancel
-      // (AbortError via connectController, which the Cancel button shares).
+      // natively with a hard timeout.
       async function checkReachable(url) {
-        connectController = new AbortController();
-        let timer;
-        const timeout = new Promise((_, reject) => {
-          timer = setTimeout(() => {
-            connectController.abort();
-            reject(new Error(`No response within ${CONNECT_TIMEOUT_MS / 1000}s`));
-          }, CONNECT_TIMEOUT_MS);
-        });
-        try {
-          await Promise.race([
-            fetch(url, { method: "HEAD", mode: "no-cors", signal: connectController.signal }),
-            timeout,
-          ]);
-        } finally {
-          clearTimeout(timer);
-        }
+        return invoke("check_server_reachable", { url });
       }
 
       // Connect to a server - navigate directly (no iframe).
@@ -687,6 +669,7 @@
         }
 
         const label = serverName || url;
+        const attemptId = (connectAttemptId += 1);
 
         // Show connecting overlay
         document.getElementById("launcher").classList.add("hidden");
@@ -705,8 +688,7 @@
         try {
           await checkReachable(url);
         } catch (e) {
-          if (e?.name === "AbortError") {
-            // User cancelled; cancelAutoConnect owns the UI restore.
+          if (isStaleConnectAttempt(attemptId)) {
             return false;
           }
           const reason = e?.message || String(e);
@@ -723,6 +705,10 @@
             errorMsg.textContent = t("desktop.launcher.connection_failed_message", label);
             errorMsg.style.display = "block";
           }
+          return false;
+        }
+
+        if (isStaleConnectAttempt(attemptId)) {
           return false;
         }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Once};
 use std::thread;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::menu::{CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 use tauri::Manager;
@@ -122,6 +122,29 @@ fn server_connecting(app: tauri::AppHandle, url: String) {
 #[tauri::command]
 fn server_connect_failed(url: String, error: String) {
     log::error!("[Launcher] Connection to {url} failed: {error}");
+}
+
+/// Reachability preflight before the launcher webview navigates to `url`: a bare
+/// `window.location.href` to a dead host hangs `WKWebView` forever. Done natively
+/// rather than a webview `fetch` because `WebKit` blocks private/Tailscale HTTP hosts
+/// from the launcher origin
+#[tauri::command]
+async fn check_server_reachable(url: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let agent = ureq::Agent::new_with_config(
+            ureq::Agent::config_builder()
+                .timeout_global(Some(Duration::from_secs(5)))
+                .build(),
+        );
+        // Any HTTP response means the host answered; only transport/timeout/TLS
+        // failures count as unreachable.
+        match agent.head(&url).call() {
+            Ok(_) | Err(ureq::Error::StatusCode(_)) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 /// Called by frontend to signal companion integration is ready
@@ -608,6 +631,7 @@ pub fn run() {
             get_i18n_bundle,
             server_connecting,
             server_connect_failed,
+            check_server_reachable,
             companion_ready,
             navigate_to_launcher,
             get_now_playing,


### PR DESCRIPTION
Move the pre-flight logic to native code as Webview pre-flight can (and will) reject some things that are actually working, like http over non-local IPs like you might get when using VPNs like Tailscale. Fixes #80