### PR TITLE
fix: use advertised MA URL for discovery

### DIFF
--- a/src-tauri/src/mdns_discovery.rs
+++ b/src-tauri/src/mdns_discovery.rs
@@ -1,30 +1,24 @@
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 use serde::Serialize;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 /// Music Assistant mDNS service type
 const MA_SERVICE_TYPE: &str = "_mass._tcp.local.";
 
-/// Parse IP address from a base URL
-/// Supports `<http://192.168.1.47:8095>` or `<https://10.0.0.1:443>` format
-/// Returns None if the URL format is invalid or contains non-parseable IP
-fn parse_ip_from_base_url(url_str: &str) -> Option<std::net::IpAddr> {
-    let clean = url_str.replace("http://", "").replace("https://", "");
-    clean.split(':').next()?.parse::<std::net::IpAddr>().ok()
+/// Select the Music Assistant server URL advertised in mDNS TXT records.
+fn select_advertised_url(internal_url: Option<&str>, base_url: Option<&str>) -> Option<String> {
+    internal_url
+        .or(base_url)
+        .map(str::trim)
+        .map(|url| url.trim_end_matches('/'))
+        .filter(|url| url.starts_with("http://") || url.starts_with("https://"))
+        .map(ToString::to_string)
 }
 
-/// Select preferred IP address from available options
-/// Prioritizes: TXT record IP > IPv4 from addresses > IPv6 from addresses
-/// Returns None if no IP is available
-fn select_preferred_ip(
-    txt_ip: Option<std::net::IpAddr>,
-    addresses: &[std::net::IpAddr],
-) -> Option<std::net::IpAddr> {
-    if let Some(ip) = txt_ip {
-        return Some(ip);
-    }
+/// Select preferred IP address from mDNS address data.
+/// Prioritizes IPv4 over IPv6 and returns None if no IP is available.
+fn select_preferred_ip(addresses: &[std::net::IpAddr]) -> Option<std::net::IpAddr> {
     if addresses.is_empty() {
         return None;
     }
@@ -33,6 +27,14 @@ fn select_preferred_ip(
         .find(|addr| addr.is_ipv4())
         .or(addresses.first())
         .copied()
+}
+
+/// Format an IP address for use as a URL host.
+fn format_ip_host(ip: std::net::IpAddr) -> String {
+    match ip {
+        std::net::IpAddr::V4(ip) => ip.to_string(),
+        std::net::IpAddr::V6(ip) => format!("[{ip}]"),
+    }
 }
 
 /// Discovered Music Assistant server
@@ -59,100 +61,82 @@ pub fn discover_servers(timeout_secs: u64) -> Result<Vec<DiscoveredServer>, Stri
         .browse(MA_SERVICE_TYPE)
         .map_err(|e| format!("Failed to browse mDNS: {}", e))?;
 
-    let servers: Arc<Mutex<HashMap<String, DiscoveredServer>>> =
-        Arc::new(Mutex::new(HashMap::new()));
-    let servers_clone = servers.clone();
+    let mut servers = HashMap::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
 
-    // Spawn a thread to collect discovered servers
-    let handle = std::thread::spawn(move || {
-        let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
+    while std::time::Instant::now() < deadline {
+        // Use a short timeout to allow checking the deadline.
+        match receiver.recv_timeout(Duration::from_millis(100)) {
+            Ok(ServiceEvent::ServiceResolved(info)) => {
+                // Extract server information.
+                let name = info.get_fullname().to_string();
+                let friendly_name = info
+                    .get_fullname()
+                    .trim_end_matches(".local.")
+                    .trim_end_matches("._mass._tcp")
+                    .to_string();
 
-        while std::time::Instant::now() < deadline {
-            // Use a short timeout to allow checking the deadline
-            match receiver.recv_timeout(Duration::from_millis(100)) {
-                Ok(event) => {
-                    if let ServiceEvent::ServiceResolved(info) = event {
-                        // Extract server information
-                        let name = info.get_fullname().to_string();
-                        let friendly_name = info
-                            .get_fullname()
-                            .trim_end_matches(".local.")
-                            .trim_end_matches("._mass._tcp")
-                            .to_string();
+                // Check TXT records for additional info.
+                let properties = info.get_properties();
 
-                        // Check TXT records for additional info
-                        let properties = info.get_properties();
+                let server_id = properties
+                    .get("server_id")
+                    .or_else(|| properties.get("id"))
+                    .map(|v| v.val_str().to_string());
 
-                        let server_id = properties
-                            .get("server_id")
-                            .or_else(|| properties.get("id"))
-                            .map(|v| v.val_str().to_string());
+                let advertised_url = select_advertised_url(
+                    properties.get("internal_url").map(|v| v.val_str()),
+                    properties.get("base_url").map(|v| v.val_str()),
+                );
 
-                        // Try to get the correct IP from TXT records
-                        // Music Assistant may include base_url with the actual server IP
-                        let ip_from_txt: Option<std::net::IpAddr> = properties
-                            .get("base_url")
-                            .and_then(|base_url| parse_ip_from_base_url(base_url.val_str()));
+                let port = info.get_port();
 
-                        let port = info.get_port();
+                // Use the advertised MA URL for connecting, falling back to mDNS
+                // address data only if a service does not publish the current
+                // ServerInfoMessage URL fields.
+                let addresses: Vec<std::net::IpAddr> =
+                    info.get_addresses().iter().copied().collect();
+                let ip: std::net::IpAddr = match select_preferred_ip(&addresses) {
+                    Some(ip) => ip,
+                    None => continue,
+                };
 
-                        // Use IP from TXT record if available, otherwise fall back to addresses
-                        let addresses: Vec<std::net::IpAddr> =
-                            info.get_addresses().iter().copied().collect();
-                        let ip: std::net::IpAddr =
-                            match select_preferred_ip(ip_from_txt, &addresses) {
-                                Some(ip) => ip,
-                                None => continue,
-                            };
+                let host = format_ip_host(ip);
+                let url = advertised_url.unwrap_or_else(|| format!("http://{}:{}", host, port));
+                let https = url.starts_with("https://");
+                let address = format!("{}:{}", host, port);
 
-                        // Check if HTTPS is available (default to false)
-                        let https = properties
-                            .get("https")
-                            .is_some_and(|v| v.val_str() == "true" || v.val_str() == "1");
+                let server = DiscoveredServer {
+                    name: friendly_name.clone(),
+                    server_id: server_id.clone(),
+                    address,
+                    url: url.clone(),
+                    https,
+                };
 
-                        let protocol = if https { "https" } else { "http" };
-                        let url = format!("{}://{}:{}", protocol, ip, port);
-                        let address = format!("{}:{}", ip, port);
-
-                        let server = DiscoveredServer {
-                            name: friendly_name.clone(),
-                            server_id: server_id.clone(),
-                            address,
-                            url: url.clone(),
-                            https,
-                        };
-
-                        // Use server_id as key if available, otherwise fullname
-                        // This helps deduplicate servers responding on multiple interfaces
-                        let key = server_id.clone().unwrap_or(name);
-
-                        if let Ok(mut map) = servers_clone.lock() {
-                            // Only insert if not already present
-                            map.entry(key).or_insert(server);
-                        }
-                    }
-                }
-                Err(flume::RecvTimeoutError::Timeout) => {}
-                Err(flume::RecvTimeoutError::Disconnected) => break,
+                // Use server_id as key if available, otherwise fullname. This helps
+                // deduplicate servers responding on multiple interfaces.
+                let key = server_id.clone().unwrap_or(name);
+                servers.entry(key).or_insert(server);
             }
+            Ok(_) | Err(flume::RecvTimeoutError::Timeout) => {}
+            Err(flume::RecvTimeoutError::Disconnected) => break,
         }
-    });
+    }
 
-    // Wait for the discovery thread to complete
-    let _ = handle.join();
-
-    // Stop browsing
+    // Stop browsing while the receiver is still alive, then briefly drain the
+    // expected SearchStopped event so mdns-sd does not warn about a closed channel.
     let _ = mdns.stop_browse(MA_SERVICE_TYPE);
+    let stop_deadline = std::time::Instant::now() + Duration::from_millis(500);
+    while std::time::Instant::now() < stop_deadline {
+        match receiver.recv_timeout(Duration::from_millis(50)) {
+            Ok(ServiceEvent::SearchStopped(service)) if service == MA_SERVICE_TYPE => break,
+            Ok(_) | Err(flume::RecvTimeoutError::Timeout) => {}
+            Err(flume::RecvTimeoutError::Disconnected) => break,
+        }
+    }
 
-    // Return the discovered servers
-    let result: Vec<DiscoveredServer> = servers
-        .lock()
-        .map_err(|_| "Failed to lock servers")?
-        .values()
-        .cloned()
-        .collect();
-
-    Ok(result)
+    Ok(servers.values().cloned().collect())
 }
 
 #[cfg(test)]
@@ -161,20 +145,29 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
-    fn test_parse_ip_from_base_url() {
-        let v4 = |a, b, c, d| Some(IpAddr::V4(Ipv4Addr::new(a, b, c, d)));
-        let cases: Vec<(&str, Option<IpAddr>)> = vec![
-            ("http://192.168.1.47:8095", v4(192, 168, 1, 47)),
-            ("https://10.0.0.1:443", v4(10, 0, 0, 1)),
-            ("192.168.1.100:8095", v4(192, 168, 1, 100)),
-            ("http://[::1]:8095", None), // Brackets don't parse as bare IpAddr
-            ("http://not_an_ip:8095", None),
-            ("", None),
-            ("http://", None),
-        ];
-        for (input, expected) in cases {
-            assert_eq!(parse_ip_from_base_url(input), expected, "input: {input}");
-        }
+    fn test_select_advertised_url() {
+        assert_eq!(
+            select_advertised_url(
+                Some("https://192.168.1.47:8095/"),
+                Some("http://192.168.1.47:8095")
+            ),
+            Some("https://192.168.1.47:8095".to_string())
+        );
+        assert_eq!(
+            select_advertised_url(None, Some(" http://192.168.1.47:8095/ ")),
+            Some("http://192.168.1.47:8095".to_string())
+        );
+        assert_eq!(select_advertised_url(Some("192.168.1.47:8095"), None), None);
+        assert_eq!(select_advertised_url(Some(""), Some("")), None);
+    }
+
+    #[test]
+    fn test_format_ip_host() {
+        assert_eq!(
+            format_ip_host(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 47))),
+            "192.168.1.47"
+        );
+        assert_eq!(format_ip_host(IpAddr::V6(Ipv6Addr::LOCALHOST)), "[::1]");
     }
 
     #[test]
@@ -182,23 +175,18 @@ mod tests {
         let v4 = |a, b, c, d| IpAddr::V4(Ipv4Addr::new(a, b, c, d));
         let v6_loopback = IpAddr::V6(Ipv6Addr::LOCALHOST);
 
-        // TXT IP takes precedence over mDNS addresses
-        assert_eq!(
-            select_preferred_ip(Some(v4(192, 168, 1, 1)), &[v4(10, 0, 0, 1)]),
-            Some(v4(192, 168, 1, 1))
-        );
         // IPv4 preferred over IPv6
         assert_eq!(
-            select_preferred_ip(None, &[v6_loopback, v4(192, 168, 1, 1)]),
+            select_preferred_ip(&[v6_loopback, v4(192, 168, 1, 1)]),
             Some(v4(192, 168, 1, 1))
         );
         // Falls back to IPv6 when no IPv4 available
-        assert_eq!(select_preferred_ip(None, &[v6_loopback]), Some(v6_loopback));
-        // No addresses and no TXT → None
-        assert_eq!(select_preferred_ip(None, &[]), None);
+        assert_eq!(select_preferred_ip(&[v6_loopback]), Some(v6_loopback));
+        // No addresses → None
+        assert_eq!(select_preferred_ip(&[]), None);
         // Multiple IPv4 → returns first
         assert_eq!(
-            select_preferred_ip(None, &[v4(192, 168, 1, 1), v4(10, 0, 0, 1)]),
+            select_preferred_ip(&[v4(192, 168, 1, 1), v4(10, 0, 0, 1)]),
             Some(v4(192, 168, 1, 1))
         );
     }


### PR DESCRIPTION
We were looking for whether https was enabled in a TXT field which didn't exist. Rewrote to match how the MA server actually advertises, including fall-back to older servers. Additionally, cleaned up a useless thread hop.

Closes #50