### PR TITLE
fix: Work around older versions of WebKitGTK

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -698,14 +698,30 @@ fn apply_window_defaults<R: tauri::Runtime, M: tauri::Manager<R>>(
     builder
 }
 
+#[cfg(target_os = "linux")]
+fn parse_major_minor(version: &str) -> Option<(u32, u32)> {
+    let mut parts = version.split('.').map(|part| part.parse::<u32>().ok());
+    Some((parts.next()??, parts.next()??))
+}
+
+#[cfg(target_os = "linux")]
+fn webkit_has_legacy_renderer() -> bool {
+    tauri::webview_version()
+        .ok()
+        .as_deref()
+        .and_then(parse_major_minor)
+        .is_some_and(|version| version < (2, 46))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // WebKitGTK's DMABUF renderer fails to initialize EGL on some Mesa/Wayland
-    // setups, aborting with `EGL_BAD_PARAMETER`. Disable it by default; honor an
-    // explicit override (e.g. `=0`) if the user set one.  Safe to call here:
-    // process start, before any GTK/WebKit or thread init.
+    // Newer versions of WebKitGTK crash if this is set to 1 on a machine with a
+    // real GPU. Older versions crash if it isn't. We can delete this and the
+    // associate webkit_has_legacy_renderer in 2027, as everyone should have
+    // upgraded off of the affected version by then. Hopefully.
     #[cfg(target_os = "linux")]
-    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() && webkit_has_legacy_renderer()
+    {
         std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
     }
 


### PR DESCRIPTION
We need to set WEBKIT_DISABLE_DMABUF_RENDERER to 1 on older versions of WebkitGTK with machines that have GPUs, but we need to set it to 0 on newer versions on machines with GPUs. Machines without GPUs work fine either way.

Closes #92