### PR TITLE
fix: Cleanup linux builds, instructions, logs

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -234,14 +234,17 @@ jobs:
 
       - name: Create Flatpak bundle
         if: startsWith(matrix.platform, 'ubuntu')
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          flatpak build-bundle flatpak-repo \
-            "music-assistant-companion-${{ matrix.asset_arch }}.flatpak" \
-            io.music_assistant.Companion
+          BUNDLE="Music.Assistant${VERSION:+_$VERSION}_${{ matrix.asset_arch }}.flatpak"
+          echo "FLATPAK_BUNDLE=$BUNDLE" >> "$GITHUB_ENV"
+          flatpak build-bundle flatpak-repo "$BUNDLE" io.music_assistant.Companion
 
       - name: Upload Flatpak bundle to release
         if: startsWith(matrix.platform, 'ubuntu') && inputs.upload_release_assets == true
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
-        run: gh release upload "$RELEASE_TAG" "music-assistant-companion-${{ matrix.asset_arch }}.flatpak" --clobber
+        run: gh release upload "$RELEASE_TAG" "$FLATPAK_BUNDLE" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /packaging/flatpak/.flatpak-builder
 /packaging/flatpak/repo
 /packaging/flatpak/*.flatpak
+/*.flatpak

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
   <p align="center">
    <img width="150" height="150" src="app-icon.png" alt="Logo">
   </p>
-	<h1 align="center"><b>Music Assistant Desktop Companion App</b></h1>
-	<p align="center">
-		A native desktop companion app for Music Assistant
+    <h1 align="center"><b>Music Assistant Desktop Companion App</b></h1>
+    <p align="center">
+       A native desktop companion app for Music Assistant
     <br />
     <a href="https://music-assistant.io/"><strong>Music Assistant »</strong></a>
     <br />
@@ -13,15 +13,15 @@
   </p>
 </p>
 
-**About Music Assistant**
+## About Music Assistant
 
 Music Assistant is a free, opensource Media library manager that connects to your streaming services and a wide range of connected speakers. The server is the beating heart, the core of Music Assistant and must run on an always-on device like a Raspberry Pi, a NAS or an Intel NUC or alike. The desktop app discovers running Music Assistant servers running on your network and allows you to connect to one, basically wrapping the frontend into this app and provides a couple of native features, such as a sendspin player and discord rich presence. It will sit in your system tray, ready to control playback or show the interface.
 
-**Documentation and support**
+### Documentation and support
 
-Documentation https://music-assistant.io
+[Documentation](https://music-assistant.io)
 
-Beta Documentation https://beta.music-assistant.io
+[Beta Documentation](https://beta.music-assistant.io)
 
 For issues, please go to [the issue tracker](https://github.com/music-assistant/support/issues).
 
@@ -29,19 +29,19 @@ For feature requests, please see [feature requests](https://github.com/music-ass
 
 ---
 
-## Downloads
+### Downloads
 
-| Platform    | Architecture             | Download                                                                                                                                                                                                                        |
-| ----------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Windows** | x64                      | [.msi installer](https://github.com/music-assistant/desktop-app/releases/latest) \| [.exe installer](https://github.com/music-assistant/desktop-app/releases/latest)                                                            |
-| **macOS**   | Apple Silicon (M1/M2/M3) | [.dmg](https://github.com/music-assistant/desktop-app/releases/latest)                                                                                                                                                          |
-| **macOS**   | Intel                    | [.dmg](https://github.com/music-assistant/desktop-app/releases/latest)                                                                                                                                                          |
-| **Linux**   | x64                      | [.deb](https://github.com/music-assistant/desktop-app/releases/latest) \| [.AppImage](https://github.com/music-assistant/desktop-app/releases/latest) \| [.rpm](https://github.com/music-assistant/desktop-app/releases/latest) |
-| **Linux**   | ARM64                    | [.deb](https://github.com/music-assistant/desktop-app/releases/latest) \| [.AppImage](https://github.com/music-assistant/desktop-app/releases/latest) \| [.rpm](https://github.com/music-assistant/desktop-app/releases/latest) |
+| Platform    | Architecture             | Download                                                                                                                                                                                                                                                                                                      |
+| ----------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Windows** | x64                      | [.msi installer](https://github.com/music-assistant/desktop-app/releases/latest) \| [.exe installer](https://github.com/music-assistant/desktop-app/releases/latest)                                                                                                                                          |
+| **macOS**   | Apple Silicon (M1/M2/M3) | [.dmg](https://github.com/music-assistant/desktop-app/releases/latest)                                                                                                                                                                                                                                        |
+| **macOS**   | Intel                    | [.dmg](https://github.com/music-assistant/desktop-app/releases/latest)                                                                                                                                                                                                                                        |
+| **Linux**   | x64                      | [.deb](https://github.com/music-assistant/desktop-app/releases/latest) \| [.AppImage](https://github.com/music-assistant/desktop-app/releases/latest) \| [.rpm](https://github.com/music-assistant/desktop-app/releases/latest) \| [.flatpak](https://github.com/music-assistant/desktop-app/releases/latest) |
+| **Linux**   | ARM64                    | [.deb](https://github.com/music-assistant/desktop-app/releases/latest) \| [.AppImage](https://github.com/music-assistant/desktop-app/releases/latest) \| [.rpm](https://github.com/music-assistant/desktop-app/releases/latest) \| [.flatpak](https://github.com/music-assistant/desktop-app/releases/latest) |
 
 > All downloads available on the [Releases page](https://github.com/music-assistant/desktop-app/releases/latest)
 
-## Features
+### Features
 
 - **Native Audio Playback** - High-quality audio output via Sendspin protocol with device selection
 - **System Tray Integration** - Control playback and see what's playing from the system tray
@@ -49,7 +49,7 @@ For feature requests, please see [feature requests](https://github.com/music-ass
 - **Discord Rich Presence** - Show what you're listening to on Discord
 - **Server Discovery** - Automatic discovery of Music Assistant servers via mDNS
 
-## Architecture
+### Architecture
 
 The companion app wraps the Music Assistant frontend (hosted on your MA server) in a native webview, while providing some additional native features:
 
@@ -58,25 +58,24 @@ The companion app wraps the Music Assistant frontend (hosted on your MA server) 
 - Background operation with tray icon
 - Auto-start on system boot
 
-## Installation
+### Installation
 
-### Windows
+#### Windows
 
 Download and run the `.msi` or `.exe` installer from the downloads table above.
 
-### macOS
+#### macOS
 
 Download the `.dmg` file for your architecture (Apple Silicon for M1/M2/M3 Macs, Intel for older Macs).
 
-<!--
 Or install via Homebrew:
+
 ```bash
 brew tap music-assistant/tap
 brew install music-assistant
 ```
--->
 
-### Linux
+#### Linux
 
 **Debian/Ubuntu:** Download and install the `.deb` package:
 
@@ -90,6 +89,27 @@ sudo dpkg -i Music.Assistant_*_amd64.deb
 sudo rpm -i Music.Assistant-*-1.x86_64.rpm
 ```
 
+**Flatpak:** Download and install the `.flatpak` bundle for your architecture:
+
+```bash
+flatpak install Music.Assistant_*_x86_64.flatpak
+flatpak run io.music_assistant.Companion
+```
+
+> Installing the bundle pulls in the GNOME runtime, so make sure the [Flathub remote](https://flathub.org/setup) is configured first.
+
+**Arch Linux:** Available on the [AUR](https://aur.archlinux.org/), e.g. with an AUR helper:
+
+```bash
+yay -S music-assistant-desktop
+```
+
+- [music-assistant-desktop](https://aur.archlinux.org/packages/music-assistant-desktop) - builds from the latest release
+- [music-assistant-desktop-bin](https://aur.archlinux.org/packages/music-assistant-desktop-bin) - prebuilt binary from the latest release
+- [music-assistant-desktop-git](https://aur.archlinux.org/packages/music-assistant-desktop-git) - builds from the latest git commit
+
+These are maintained by MA community member [Raggi](https://github.com/raggi), which is greatly appreciated.
+
 **Other distributions:** Download the `.AppImage`, make it executable, and run:
 
 ```bash
@@ -97,11 +117,11 @@ chmod +x Music.Assistant_*.AppImage
 ./Music.Assistant_*.AppImage
 ```
 
-## Troubleshooting
+### Troubleshooting
 
 If the app does not connect, playback controls stop responding, or the app crashes, please include logs when opening an [issue](https://github.com/music-assistant/desktop-app/issues/new/choose).
 
-### Enable debug logging
+#### Enable debug logging
 
 1. Open **Settings** from the Music Assistant tray/menubar icon.
 2. Enable **Debug logging**.
@@ -109,7 +129,11 @@ If the app does not connect, playback controls stop responding, or the app crash
 4. Use the tray/menubar menu item **Open log file** to open the current log.
 5. Attach the relevant log output to your bug report.
 
-### Linux crash diagnostics
+##### If the issue relates to audio quality
+
+- Enable **Trace logging** by enabling debug logging and then trace in the same settings window.
+
+#### Linux crash diagnostics
 
 For Linux crashes, especially AppImage crashes that only print `Segmentation fault` in the terminal, run the app from a terminal with extra diagnostics enabled:
 
@@ -138,11 +162,11 @@ info sharedlibrary
 
 If the AppImage crashes but the `.deb` or `.rpm` package works on the same machine, please mention that. It helps identify AppImage-specific GTK/WebKit/GLib library issues.
 
-## Development & Contributing
+### Development & Contributing
 
 Check the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
-## License
+### License
 
 [Apache-2.0](LICENSE)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-assistant-desktop-app",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "type": "module",
   "description": "Music Assistant Desktop Companion App",
   "scripts": {

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -37,8 +37,13 @@ To create a single-file bundle for local installation/testing:
 
 ```bash
 flatpak-builder --force-clean --repo=repo build-dir packaging/flatpak/io.music_assistant.Companion.yml
-flatpak build-bundle repo music-assistant-companion.flatpak io.music_assistant.Companion
+flatpak build-bundle repo Music.Assistant_x86_64.flatpak io.music_assistant.Companion
 ```
+
+Release CI names the bundle to match the other release assets:
+`Music.Assistant_<version>_<arch>.flatpak` (see the `Create Flatpak bundle` step
+in `.github/workflows/build-packages.yml`). The bundle filename is cosmetic —
+the installed application ID is always `io.music_assistant.Companion`.
 
 ## Notes
 

--- a/packaging/flatpak/io.music_assistant.Companion.metainfo.xml
+++ b/packaging/flatpak/io.music_assistant.Companion.metainfo.xml
@@ -22,6 +22,6 @@
     <name>The Music Assistant Team</name>
   </developer>
   <releases>
-    <release version="0.1.0" date="2026-06-30" />
+    <release version="0.0.0" date="2026-06-30" />
   </releases>
 </component>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "music-assistant"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "block2 0.6.2",
  "coreaudio-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,9 @@ license = "Apache-2.0"
 name = "music-assistant"
 repository = "https://github.com/music-assistant/desktop-app"
 rust-version = "1.85"
-version = "0.1.0"
+# Placeholder, do not use
+# Display code must read the Tauri package info
+version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -849,7 +849,7 @@ pub fn run() {
 
             log::info!(
                 "[App] Music Assistant Companion v{} starting (debug logging: {})",
-                env!("CARGO_PKG_VERSION"),
+                app.package_info().version,
                 if loaded_settings.debug_logging {
                     "on"
                 } else {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Music Assistant",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "identifier": "io.music-assistant.companion",
   "mainBinaryName": "music-assistant-companion",
   "build": {


### PR DESCRIPTION
- Make the flatpak filenames match everything else, including have the version number
- Notice we weren't outputting the right version number to the log file, fix that
- Notice we're arbitrarily using 0.1.0 as our placeholder, replaced with 0.0.0 to make it obvious it's just a placeholder
- Add flatpak instructions to the README
- Add ArchLinux instructions to the README
- Cleanup the README formatting while I was there