### PR TITLE
fix: scope forced XWayland to GNOME on Linux, disable DMABUF there

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -739,6 +739,12 @@ fn webkit_has_legacy_renderer() -> bool {
         .is_some_and(|version| version < (2, 46))
 }
 
+#[cfg(target_os = "linux")]
+fn running_gnome() -> bool {
+    std::env::var("XDG_CURRENT_DESKTOP")
+        .is_ok_and(|desktops| desktops.split(':').any(|d| d.eq_ignore_ascii_case("GNOME")))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Newer versions of WebKitGTK crash if this is set to 1 on a machine with a
@@ -751,11 +757,20 @@ pub fn run() {
         std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
     }
 
-    // GNOME/Wayland breaks tray apps in subtle ways. Run under XWayland instead;
-    // honor an explicit GDK_BACKEND override.
+    // The forced-XWayland fallback fixes GNOME/Wayland tray and
+    // window-management quirks. Limit it to GNOME, the only desktop it is known
+    // to be needed on; XWayland can degrade compositors that manage window
+    // geometry themselves, such as the tiling ones, so default the rest to
+    // native Wayland. Honor an explicit GDK_BACKEND override either way.
     #[cfg(target_os = "linux")]
-    if std::env::var_os("GDK_BACKEND").is_none() {
+    if std::env::var_os("GDK_BACKEND").is_none() && running_gnome() {
         std::env::set_var("GDK_BACKEND", "x11");
+
+        // WebKit's DMABUF renderer paints a blank window under XWayland on
+        // current WebKitGTK, so pin it off on the branch where we force XWayland.
+        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
     }
 
     let context = tauri::generate_context!();


### PR DESCRIPTION
Forcing GDK_BACKEND=x11 for every Linux session (82abecb, #93; refs #59) fixes GNOME/Wayland tray and window-management quirks, but also applies XWayland to sessions where it is not known to be needed and can degrade compositors that manage window geometry themselves, such as the tiling ones (niri, sway, Hyprland), e.g. worse scaling and input handling. Gate the fallback on XDG_CURRENT_DESKTOP=GNOME, the only desktop the fix is known to require, so other sessions stay on native Wayland unless they opt in. An explicit GDK_BACKEND override is still honored.

The unconditional DMABUF-renderer disable added in bab6991 (#61) previously masked this, because XWayland plus WebKit's DMABUF renderer paints a blank window on current WebKitGTK (2.52). Making that disable conditional on legacy WebKitGTK in 65f31d5 (#108) re-enabled the renderer for >= 2.46 and exposed the blank window on the forced-XWayland path. Re-disable DMABUF on the same branch where we force XWayland; native Wayland sessions keep the renderer, which renders correctly here.

Refers to #93, #108, #61, #59
Fixes #115