### PR TITLE
feat: Update warning popup for companion support

### DIFF
--- a/src-tauri/resources/translations/en.json
+++ b/src-tauri/resources/translations/en.json
@@ -20,8 +20,8 @@
       "settings_title": "Music Assistant - Settings"
     },
     "dialog": {
-      "outdated_server_message": "The Music Assistant server you connected to may be running an older version that doesn't support all companion app features.\n\nPlease update your Music Assistant server for the best experience.",
-      "outdated_server_title": "Outdated Server"
+      "companion_server_message": "Music Assistant could not verify companion app support. The connection will continue, but this device may not show the app badge.",
+      "companion_server_title": "App Badge May Be Missing"
     },
     "discord": {
       "download_companion": "Download companion",

--- a/src-tauri/resources/translations/nl.json
+++ b/src-tauri/resources/translations/nl.json
@@ -19,10 +19,6 @@
       "name": "Music Assistant",
       "settings_title": "Music Assistant - Instellingen"
     },
-    "dialog": {
-      "outdated_server_message": "De Music Assistant-server waarmee je verbinding hebt gemaakt, draait mogelijk een oudere versie die niet alle functies van de bijbehorende app ondersteunt.\n\nWerk je Music Assistant-server bij voor de beste gebruikerservaring.",
-      "outdated_server_title": "Verouderde server"
-    },
     "discord": {
       "download_companion": "Download companion",
       "unknown_artist": "Onbekende Artiest",

--- a/src-tauri/resources/translations/sr.json
+++ b/src-tauri/resources/translations/sr.json
@@ -19,10 +19,6 @@
       "name": "„Music Assistant“",
       "settings_title": "„Music Assistant“ - Подешавања"
     },
-    "dialog": {
-      "outdated_server_message": "Сервер „Music Assistant“ на који сте се повезали можда користи старију верзију која не подржава све функције пратеће апликације.\n\nАжурирајте сервер „Music Assistant“ за најбоље искуство.",
-      "outdated_server_title": "Застарели сервер"
-    },
     "discord": {
       "download_companion": "Преузми пратећу апликацију",
       "unknown_artist": "Непознати извођач",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,7 +60,7 @@ static CURRENT_MA_SESSION: Mutex<Option<CurrentMaSession>> = Mutex::new(None);
 static SERVER_CONNECT_TIME: AtomicU64 = AtomicU64::new(0);
 // Whether the frontend has reported companion ready
 static COMPANION_READY: AtomicBool = AtomicBool::new(false);
-// Timeout in seconds before showing outdated server warning
+// Timeout in seconds before warning that companion feature detection did not complete
 const COMPANION_READY_TIMEOUT_SECS: u64 = 30;
 
 /// Check if running in a companion app (desktop, mobile, etc.)
@@ -116,10 +116,10 @@ fn server_connecting(app: tauri::AppHandle, url: String) {
             // Check if we're still waiting for the same connection
             let connect_time = SERVER_CONNECT_TIME.load(Ordering::SeqCst);
             if connect_time > 0 {
-                // Show native warning dialog
+                // Show native warning dialog for companion feature detection timeout
                 app.dialog()
-                    .message(i18n::tr("desktop.dialog.outdated_server_message"))
-                    .title(i18n::tr("desktop.dialog.outdated_server_title"))
+                    .message(i18n::tr("desktop.dialog.companion_server_message"))
+                    .title(i18n::tr("desktop.dialog.companion_server_title"))
                     .kind(MessageDialogKind::Warning)
                     .blocking_show();
             }


### PR DESCRIPTION
The old warning was very confusing for users, as it almost never *actually* meant that they were connecting to an older server.