### PR TITLE
Add Linux package repositories and update routing

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -64,31 +64,85 @@ jobs:
             rust_target: aarch64-apple-darwin
             args: --target aarch64-apple-darwin
             asset_arch: aarch64
+            package: tauri
+            distribution: native
           - name: macos-x86_64
             platform: macos-latest
             rust_target: x86_64-apple-darwin
             args: --target x86_64-apple-darwin
             asset_arch: x86_64
-          - name: linux-x86_64
+            package: tauri
+            distribution: native
+          - name: linux-x86_64-appimage
+            platform: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-gnu
+            args: --bundles appimage
+            asset_arch: x86_64
+            package: tauri
+            distribution: appimage
+          - name: linux-x86_64-deb
+            platform: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-gnu
+            args: --bundles deb --config '{"bundle":{"createUpdaterArtifacts":false}}'
+            asset_arch: x86_64
+            package: tauri
+            distribution: deb
+          - name: linux-x86_64-rpm
+            platform: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-gnu
+            args: --bundles rpm --config '{"bundle":{"createUpdaterArtifacts":false}}'
+            asset_arch: x86_64
+            package: tauri
+            distribution: rpm
+          - name: linux-x86_64-flatpak
             platform: ubuntu-24.04
             rust_target: x86_64-unknown-linux-gnu
             args: ""
             asset_arch: x86_64
-          - name: linux-aarch64
+            package: flatpak
+            distribution: flatpak
+          - name: linux-aarch64-appimage
+            platform: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            args: --bundles appimage
+            asset_arch: aarch64
+            package: tauri
+            distribution: appimage
+          - name: linux-aarch64-deb
+            platform: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            args: --bundles deb --config '{"bundle":{"createUpdaterArtifacts":false}}'
+            asset_arch: aarch64
+            package: tauri
+            distribution: deb
+          - name: linux-aarch64-rpm
+            platform: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            args: --bundles rpm --config '{"bundle":{"createUpdaterArtifacts":false}}'
+            asset_arch: aarch64
+            package: tauri
+            distribution: rpm
+          - name: linux-aarch64-flatpak
             platform: ubuntu-24.04-arm
             rust_target: aarch64-unknown-linux-gnu
             args: ""
             asset_arch: aarch64
+            package: flatpak
+            distribution: flatpak
           - name: windows-x86_64
             platform: windows-latest
             rust_target: x86_64-pc-windows-msvc
             args: ""
             asset_arch: x86_64
+            package: tauri
+            distribution: native
           - name: windows-aarch64
             platform: windows-11-arm
             rust_target: aarch64-pc-windows-msvc
             args: --target aarch64-pc-windows-msvc
             asset_arch: aarch64
+            package: tauri
+            distribution: native
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.platform }}
@@ -154,7 +208,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Pin linuxdeploy for AppImage EGL fix
-        if: startsWith(matrix.platform, 'ubuntu')
+        if: matrix.distribution == 'appimage'
         shell: bash
         run: |
           TAURI_TOOLKIT_PATH="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
@@ -172,12 +226,14 @@ jobs:
         run: cargo install tauri-cli
 
       - name: Build packages
-        if: inputs.upload_release_assets == false
+        if: matrix.package == 'tauri' && inputs.upload_release_assets == false
         shell: bash
+        env:
+          MUSIC_ASSISTANT_DISTRIBUTION: ${{ matrix.distribution }}
         run: cargo tauri build ${{ matrix.args }} --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       - name: Build and upload release packages
-        if: inputs.upload_release_assets == true
+        if: matrix.package == 'tauri' && inputs.upload_release_assets == true
         uses: tauri-apps/tauri-action@v1
         timeout-minutes: 60
         env:
@@ -190,6 +246,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          MUSIC_ASSISTANT_DISTRIBUTION: ${{ matrix.distribution }}
         with:
           tagName: ${{ needs.prepare.outputs.tag }}
           releaseName: ${{ needs.prepare.outputs.tag }}
@@ -199,13 +256,13 @@ jobs:
           args: ${{ matrix.args }}
 
       - name: Install Flatpak tooling
-        if: startsWith(matrix.platform, 'ubuntu')
+        if: matrix.package == 'flatpak'
         run: |
           sudo apt-get install -y flatpak flatpak-builder git python3-venv
           sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Install Flatpak SDKs
-        if: startsWith(matrix.platform, 'ubuntu')
+        if: matrix.package == 'flatpak'
         run: |
           sudo flatpak install -y flathub \
             org.gnome.Platform//49 \
@@ -213,19 +270,19 @@ jobs:
             org.freedesktop.Sdk.Extension.rust-stable//25.08
 
       - name: Verify Cargo Flatpak sources are current
-        if: startsWith(matrix.platform, 'ubuntu')
+        if: matrix.package == 'flatpak'
         run: |
           packaging/flatpak/generate-cargo-sources.sh
           git diff --exit-code -- packaging/flatpak/cargo-sources.json
 
       - name: Build Flatpak
-        if: startsWith(matrix.platform, 'ubuntu')
+        if: matrix.package == 'flatpak'
         run: |
-          flatpak-builder --force-clean --repo=flatpak-repo \
+          flatpak-builder --force-clean --repo=flatpak-repo --default-branch=stable \
             build-dir packaging/flatpak/io.music_assistant.Companion.yml
 
       - name: Smoke-test Flatpak installed files
-        if: startsWith(matrix.platform, 'ubuntu')
+        if: matrix.package == 'flatpak'
         run: |
           flatpak-builder --run build-dir packaging/flatpak/io.music_assistant.Companion.yml sh -lc '
             set -e
@@ -238,18 +295,21 @@ jobs:
           '
 
       - name: Create Flatpak bundle
-        if: startsWith(matrix.platform, 'ubuntu')
+        if: matrix.package == 'flatpak'
         shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           BUNDLE="Music.Assistant${VERSION:+_$VERSION}_${{ matrix.asset_arch }}.flatpak"
           echo "FLATPAK_BUNDLE=$BUNDLE" >> "$GITHUB_ENV"
-          flatpak build-bundle flatpak-repo "$BUNDLE" io.music_assistant.Companion
+          flatpak build-bundle flatpak-repo "$BUNDLE" io.music_assistant.Companion stable
 
       - name: Upload Flatpak bundle to release
-        if: startsWith(matrix.platform, 'ubuntu') && inputs.upload_release_assets == true
+        if: matrix.package == 'flatpak' && inputs.upload_release_assets == true
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
-        run: gh release upload "$RELEASE_TAG" "$FLATPAK_BUNDLE" --clobber
+        run: |
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
+            gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --notes "Release $RELEASE_TAG"
+          gh release upload "$RELEASE_TAG" "$FLATPAK_BUNDLE" --clobber

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,3 +42,94 @@ jobs:
           else
             echo "HOMEBREW_TAP_TOKEN not set, skipping Homebrew tap update"
           fi
+
+  publish-linux-repositories:
+    needs: build
+    runs-on: ubuntu-24.04
+    if: needs.build.outputs.tag != ''
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ needs.build.outputs.tag }}
+      GPG_KEY_ID: ${{ secrets.LINUX_PACKAGE_GPG_KEY_ID }}
+      GPG_PRIVATE_KEY: ${{ secrets.LINUX_PACKAGE_GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.LINUX_PACKAGE_GPG_PASSPHRASE }}
+      PAGES_BASE_URL: https://music-assistant.github.io/desktop-app
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install repository tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            apt-utils \
+            createrepo-c \
+            flatpak \
+            flatpak-builder \
+            gnupg \
+            rpm
+
+      - name: Import Linux package signing key
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$GPG_KEY_ID" ] || [ -z "$GPG_PRIVATE_KEY" ] || [ -z "$GPG_PASSPHRASE" ]; then
+            echo "Linux package GPG secrets are required" >&2
+            exit 1
+          fi
+          install -m 700 -d ~/.gnupg
+          echo "allow-preset-passphrase" >> ~/.gnupg/gpg-agent.conf
+          gpg-connect-agent reloadagent /bye
+          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
+          for keygrip in $(gpg --batch --with-keygrip --list-secret-keys "$GPG_KEY_ID" | awk '/Keygrip/ {print $3}'); do
+            printf '%s' "$GPG_PASSPHRASE" | /usr/lib/gnupg/gpg-preset-passphrase --preset "$keygrip"
+          done
+          gpg --batch --list-secret-keys "$GPG_KEY_ID"
+
+      - name: Download release Linux assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir release-assets \
+            --pattern '*.deb' \
+            --pattern '*.rpm' \
+            --pattern '*.flatpak'
+          find release-assets -maxdepth 1 -type f -print | sort
+
+      - name: Prepare Pages tree
+        shell: bash
+        run: scripts/ci/prepare-pages-tree.sh
+
+      - name: Build APT repository
+        shell: bash
+        run: scripts/ci/build-apt-repository.sh
+
+      - name: Build RPM repository
+        shell: bash
+        run: scripts/ci/build-rpm-repository.sh
+
+      - name: Build Flatpak repository
+        shell: bash
+        run: scripts/ci/build-flatpak-repository.sh
+
+      - name: Install package instruction pages
+        shell: bash
+        run: scripts/ci/install-package-pages.sh
+
+      - name: Publish package repositories to gh-pages
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd public
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add --all
+          git commit -m "Publish Linux package repositories for $RELEASE_TAG" || exit 0
+          git push --force-with-lease origin HEAD:gh-pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,44 +203,23 @@ To set up the Homebrew tap, see [.github/homebrew/README.md](.github/homebrew/RE
 
 **Required secret:** `HOMEBREW_TAP_TOKEN` - A PAT with `repo` scope for the homebrew-tap repository.
 
-### APT Repository (Debian/Ubuntu)
+### Linux package repositories
 
-For Debian-based distributions, you have several options:
+Release CI publishes first-party Linux package repositories to GitHub Pages:
 
-1. **GitHub Releases**: Users can download `.deb` files directly from releases
-2. **Packagecloud.io**: A hosted APT repository service
-3. **Self-hosted APT repository**: Using tools like `reprepro`
+- APT: `https://music-assistant.github.io/desktop-app/apt`
+- RPM: `https://music-assistant.github.io/desktop-app/rpm`
+- Flatpak: `https://music-assistant.github.io/desktop-app/flatpak`
 
-Example Packagecloud workflow (add to release.yml):
+The app's **Check for updates** tray item uses Tauri's native updater for macOS, Windows, and AppImage builds. DEB, RPM, and Flatpak builds instead open the matching repository setup instructions so updates flow through the user's package manager. The Flatpak repository is preserved across releases so `flatpak build-update-repo --generate-static-deltas` can generate incremental update deltas.
 
-```yaml
-publish-apt:
-  needs: build
-  runs-on: ubuntu-latest
-  steps:
-    - name: Download Linux artifacts
-      uses: actions/download-artifact@v4
-      with:
-        pattern: "*linux*"
+**Required Linux package repository secrets:**
 
-    - name: Publish to Packagecloud
-      run: |
-        # Install packagecloud CLI
-        gem install package_cloud
-
-        # Push .deb files
-        for deb in *.deb; do
-          package_cloud push music-assistant/desktop/ubuntu/jammy $deb
-        done
-      env:
-        PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-```
+- `LINUX_PACKAGE_GPG_PRIVATE_KEY`: ASCII-armored private GPG key used to sign APT repository metadata, RPM packages and repository metadata, and Flatpak repository metadata.
+- `LINUX_PACKAGE_GPG_PASSPHRASE`: Passphrase for the private GPG key.
+- `LINUX_PACKAGE_GPG_KEY_ID`: GPG key fingerprint or key ID.
 
 ### Other Package Managers
-
-**Flatpak**: Requires a `com.music_assistant.Desktop.yml` manifest. Consider publishing to Flathub.
-
-**Snap**: Requires a `snapcraft.yaml` configuration. Publish to the Snap Store.
 
 **AUR (Arch Linux)**: Community members can maintain an AUR package using the AppImage or building from source.
 

--- a/packaging/flatpak/io.music_assistant.Companion.yml
+++ b/packaging/flatpak/io.music_assistant.Companion.yml
@@ -203,6 +203,7 @@ modules:
       env:
         CARGO_HOME: /run/build/music-assistant-companion/cargo
         CARGO_NET_OFFLINE: "true"
+        MUSIC_ASSISTANT_DISTRIBUTION: flatpak
     sources:
       - type: dir
         path: ../..

--- a/packaging/pages/index.html
+++ b/packaging/pages/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Music Assistant packages</title>
+  </head>
+  <body>
+    <h1>Music Assistant packages</h1>
+    <ul>
+      <li><a href="packages/deb.html">APT repository</a></li>
+      <li><a href="packages/rpm.html">RPM repository</a></li>
+      <li><a href="packages/flatpak.html">Flatpak repository</a></li>
+    </ul>
+  </body>
+</html>

--- a/packaging/pages/packages/deb.html
+++ b/packaging/pages/packages/deb.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Music Assistant APT repository</title>
+  </head>
+  <body>
+    <h1>Music Assistant APT repository</h1>
+    <p>Install updates through the Music Assistant APT repository:</p>
+    <pre><code>curl -fsSL https://music-assistant.github.io/desktop-app/apt/music-assistant.asc | sudo tee /usr/share/keyrings/music-assistant.asc &gt;/dev/null
+echo "deb [signed-by=/usr/share/keyrings/music-assistant.asc] https://music-assistant.github.io/desktop-app/apt stable main" | sudo tee /etc/apt/sources.list.d/music-assistant.list
+sudo apt update
+sudo apt install music-assistant</code></pre>
+    <p>After setup, update with <code>sudo apt update &amp;&amp; sudo apt upgrade</code>.</p>
+  </body>
+</html>

--- a/packaging/pages/packages/flatpak.html
+++ b/packaging/pages/packages/flatpak.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Music Assistant Flatpak repository</title>
+  </head>
+  <body>
+    <h1>Music Assistant Flatpak repository</h1>
+    <p>Install from the Music Assistant Flatpak repository:</p>
+    <pre><code>flatpak install --user https://music-assistant.github.io/desktop-app/flatpak/io.music_assistant.Companion.flatpakref</code></pre>
+    <p>After setup, update with <code>flatpak update io.music_assistant.Companion</code>.</p>
+  </body>
+</html>

--- a/packaging/pages/packages/rpm.html
+++ b/packaging/pages/packages/rpm.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Music Assistant RPM repository</title>
+  </head>
+  <body>
+    <h1>Music Assistant RPM repository</h1>
+    <p>Add the Music Assistant RPM repository:</p>
+    <pre><code>sudo tee /etc/yum.repos.d/music-assistant.repo &lt;&lt;'REPO'
+[music-assistant]
+name=Music Assistant
+baseurl=https://music-assistant.github.io/desktop-app/rpm/$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://music-assistant.github.io/desktop-app/rpm/RPM-GPG-KEY-music-assistant
+REPO
+sudo dnf install music-assistant</code></pre>
+    <p>After setup, update with <code>sudo dnf upgrade music-assistant</code>.</p>
+  </body>
+</html>

--- a/scripts/ci/build-apt-repository.sh
+++ b/scripts/ci/build-apt-repository.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd public
+mkdir -p apt/pool/main apt/dists/stable/main
+
+shopt -s nullglob
+debs=(../release-assets/*.deb)
+if [ ${#debs[@]} -eq 0 ]; then
+  echo "No DEB packages found in release assets" >&2
+  exit 1
+fi
+
+for deb in "${debs[@]}"; do
+  arch=$(dpkg-deb -f "$deb" Architecture)
+  mkdir -p "apt/pool/main/$arch" "apt/dists/stable/main/binary-$arch"
+  cp "$deb" "apt/pool/main/$arch/"
+done
+
+cd apt
+for arch_dir in dists/stable/main/binary-*; do
+  arch=${arch_dir##*-}
+  apt-ftparchive packages "pool/main/$arch" > "$arch_dir/Packages"
+  gzip -k -f "$arch_dir/Packages"
+done
+
+apt-ftparchive \
+  -o APT::FTPArchive::Release::Origin="Music Assistant" \
+  -o APT::FTPArchive::Release::Label="Music Assistant" \
+  -o APT::FTPArchive::Release::Suite="stable" \
+  -o APT::FTPArchive::Release::Codename="stable" \
+  -o APT::FTPArchive::Release::Components="main" \
+  -o APT::FTPArchive::Release::Architectures="amd64 arm64" \
+  release dists/stable > dists/stable/Release
+
+gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
+  --local-user "$GPG_KEY_ID" --clearsign \
+  --output dists/stable/InRelease dists/stable/Release
+
+gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
+  --local-user "$GPG_KEY_ID" --detach-sign --armor \
+  --output dists/stable/Release.gpg dists/stable/Release
+
+gpg --batch --armor --export "$GPG_KEY_ID" > music-assistant.asc

--- a/scripts/ci/build-flatpak-repository.sh
+++ b/scripts/ci/build-flatpak-repository.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd public
+mkdir -p flatpak
+if [ ! -d flatpak/repo/objects ]; then
+  rm -rf flatpak/repo
+  ostree init --mode=archive-z2 --repo=flatpak/repo
+fi
+
+shopt -s nullglob
+bundles=(../release-assets/*.flatpak)
+if [ ${#bundles[@]} -eq 0 ]; then
+  echo "No Flatpak bundles found in release assets" >&2
+  exit 1
+fi
+
+for bundle in "${bundles[@]}"; do
+  flatpak build-import-bundle --gpg-sign="$GPG_KEY_ID" flatpak/repo "$bundle"
+done
+flatpak build-update-repo --gpg-sign="$GPG_KEY_ID" --generate-static-deltas flatpak/repo
+
+gpg_key=$(gpg --batch --export "$GPG_KEY_ID" | base64 -w0)
+cat > flatpak/music-assistant.flatpakrepo <<FLATPAKREPO
+[Flatpak Repo]
+Title=Music Assistant
+Url=$PAGES_BASE_URL/flatpak/repo
+Homepage=https://www.music-assistant.io/
+Comment=Music Assistant Companion Flatpak repository
+Description=Music Assistant Companion Flatpak repository
+Icon=$PAGES_BASE_URL/packages/icon.png
+GPGKey=$gpg_key
+FLATPAKREPO
+
+cat > flatpak/io.music_assistant.Companion.flatpakref <<FLATPAKREF
+[Flatpak Ref]
+Title=Music Assistant Companion
+Name=io.music_assistant.Companion
+Branch=stable
+Url=$PAGES_BASE_URL/flatpak/repo
+SuggestRemoteName=music-assistant
+RuntimeRepo=https://dl.flathub.org/repo/flathub.flatpakrepo
+IsRuntime=false
+GPGKey=$gpg_key
+FLATPAKREF

--- a/scripts/ci/build-rpm-repository.sh
+++ b/scripts/ci/build-rpm-repository.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd public
+mkdir -p rpm/x86_64 rpm/aarch64
+
+shopt -s nullglob
+rpms=(../release-assets/*.rpm)
+if [ ${#rpms[@]} -eq 0 ]; then
+  echo "No RPM packages found in release assets" >&2
+  exit 1
+fi
+
+cat > ~/.rpmmacros <<RPMMACROS
+%_signature gpg
+%_gpg_name $GPG_KEY_ID
+%__gpg_sign_cmd %{__gpg} --batch --yes --pinentry-mode loopback --passphrase $GPG_PASSPHRASE --no-verbose --no-armor --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
+RPMMACROS
+
+for rpm in "${rpms[@]}"; do
+  rpmsign --addsign "$rpm"
+  arch=$(rpm -qp --queryformat '%{ARCH}' "$rpm")
+  case "$arch" in
+    x86_64) cp "$rpm" rpm/x86_64/ ;;
+    aarch64) cp "$rpm" rpm/aarch64/ ;;
+    *) echo "Unsupported RPM architecture: $arch" >&2; exit 1 ;;
+  esac
+done
+
+gpg --batch --armor --export "$GPG_KEY_ID" > rpm/RPM-GPG-KEY-music-assistant
+for arch in x86_64 aarch64; do
+  createrepo_c "rpm/$arch"
+  gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
+    --local-user "$GPG_KEY_ID" --detach-sign --armor \
+    --output "rpm/$arch/repodata/repomd.xml.asc" \
+    "rpm/$arch/repodata/repomd.xml"
+done

--- a/scripts/ci/install-package-pages.sh
+++ b/scripts/ci/install-package-pages.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+touch public/.nojekyll
+if [ ! -f app-icon.png ]; then
+  echo "app-icon.png is required for package pages" >&2
+  exit 1
+fi
+
+mkdir -p public/packages
+cp -R packaging/pages/. public/
+cp app-icon.png public/packages/icon.png

--- a/scripts/ci/prepare-pages-tree.sh
+++ b/scripts/ci/prepare-pages-tree.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git fetch origin gh-pages || true
+if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
+  git worktree add public origin/gh-pages
+else
+  mkdir -p public
+  git -C public init
+  git -C public remote add origin "$(git remote get-url origin)"
+  git -C public checkout -b gh-pages
+fi
+
+# APT, RPM, and instruction pages are regenerated on every release. Keep the
+# Flatpak OSTree repository so static deltas can be generated across releases.
+rm -rf public/apt public/rpm public/packages
+mkdir -p public/packages

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=MUSIC_ASSISTANT_DISTRIBUTION");
     tauri_build::build();
 }

--- a/src-tauri/resources/translations/en.json
+++ b/src-tauri/resources/translations/en.json
@@ -23,6 +23,25 @@
       "companion_server_message": "Music Assistant could not verify companion app support. The connection will continue, but this device may not show the app badge.",
       "companion_server_title": "App Badge May Be Missing"
     },
+    "updater": {
+      "available_message": "Music Assistant Companion {0} is available. Download and install it now?",
+      "available_title": "Update available",
+      "check_failed_message": "Failed to check for updates: {0}",
+      "check_failed_title": "Update check failed",
+      "install_failed_message": "Failed to install update: {0}",
+      "install_failed_title": "Update failed",
+      "no_updates_message": "Music Assistant Companion is up to date.",
+      "no_updates_title": "No updates available",
+      "open_instructions": "Open instructions",
+      "package_deb_message": "This DEB installation is updated through the Music Assistant APT repository. Open setup instructions?\n\n{0}",
+      "package_deb_title": "APT updates available",
+      "package_flatpak_message": "This Flatpak installation is updated through the Music Assistant Flatpak repository. Open setup instructions?\n\n{0}",
+      "package_flatpak_title": "Flatpak updates available",
+      "package_rpm_message": "This RPM installation is updated through the Music Assistant RPM repository. Open setup instructions?\n\n{0}",
+      "package_rpm_title": "RPM updates available",
+      "package_unknown_linux_message": "This Linux build cannot update itself automatically. Open the latest GitHub release?\n\n{0}",
+      "package_unknown_linux_title": "Manual update required"
+    },
     "discord": {
       "download_companion": "Download companion",
       "unknown_artist": "Unknown Artist",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::menu::{CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 use tauri::Manager;
-use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
+use tauri_plugin_dialog::{
+    DialogExt, MessageDialogButtons, MessageDialogKind, MessageDialogResult,
+};
 use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_updater::UpdaterExt;
 
@@ -85,6 +87,184 @@ fn is_desktop_app() -> bool {
 #[tauri::command]
 fn get_app_version(app: tauri::AppHandle) -> String {
     app.package_info().version.to_string()
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Distribution {
+    Native,
+    AppImage,
+    Deb,
+    Rpm,
+    Flatpak,
+    UnknownLinux,
+}
+
+fn distribution() -> Distribution {
+    match option_env!("MUSIC_ASSISTANT_DISTRIBUTION") {
+        Some("appimage") => Distribution::AppImage,
+        Some("deb") => Distribution::Deb,
+        Some("rpm") => Distribution::Rpm,
+        Some("flatpak") => Distribution::Flatpak,
+        _ => {
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            {
+                Distribution::Native
+            }
+            #[cfg(target_os = "linux")]
+            {
+                Distribution::UnknownLinux
+            }
+            #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+            {
+                Distribution::Native
+            }
+        }
+    }
+}
+
+const RELEASES_URL: &str = "https://github.com/music-assistant/desktop-app/releases/latest";
+const PACKAGE_UPDATE_DOCS_BASE_URL: &str = "https://music-assistant.github.io/desktop-app/packages";
+
+fn package_update_docs_url(distribution: Distribution) -> String {
+    match distribution {
+        Distribution::Deb => format!("{PACKAGE_UPDATE_DOCS_BASE_URL}/deb.html"),
+        Distribution::Rpm => format!("{PACKAGE_UPDATE_DOCS_BASE_URL}/rpm.html"),
+        Distribution::Flatpak => format!("{PACKAGE_UPDATE_DOCS_BASE_URL}/flatpak.html"),
+        Distribution::UnknownLinux | Distribution::Native | Distribution::AppImage => {
+            RELEASES_URL.to_string()
+        }
+    }
+}
+
+fn show_package_update_instructions(app: &tauri::AppHandle, distribution: Distribution) {
+    let (title_key, message_key) = match distribution {
+        Distribution::Deb => (
+            "desktop.updater.package_deb_title",
+            "desktop.updater.package_deb_message",
+        ),
+        Distribution::Rpm => (
+            "desktop.updater.package_rpm_title",
+            "desktop.updater.package_rpm_message",
+        ),
+        Distribution::Flatpak => (
+            "desktop.updater.package_flatpak_title",
+            "desktop.updater.package_flatpak_message",
+        ),
+        Distribution::UnknownLinux => (
+            "desktop.updater.package_unknown_linux_title",
+            "desktop.updater.package_unknown_linux_message",
+        ),
+        Distribution::Native | Distribution::AppImage => return,
+    };
+
+    let url = package_update_docs_url(distribution);
+    let open_label = i18n::tr("desktop.updater.open_instructions");
+    let result = app
+        .dialog()
+        .message(i18n::tr(message_key).replace("{0}", &url))
+        .title(i18n::tr(title_key))
+        .kind(MessageDialogKind::Info)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            open_label.clone(),
+            i18n::tr("common.actions.cancel"),
+        ))
+        .blocking_show_with_result();
+
+    if result == MessageDialogResult::Custom(open_label) {
+        if let Err(error) = app.opener().open_url(&url, None::<&str>) {
+            log::warn!("[Updater] Failed to open package update instructions: {error}");
+        }
+    }
+}
+
+async fn check_for_updates(app: tauri::AppHandle) {
+    let distribution = distribution();
+    if matches!(
+        distribution,
+        Distribution::Deb | Distribution::Rpm | Distribution::Flatpak | Distribution::UnknownLinux
+    ) {
+        show_package_update_instructions(&app, distribution);
+        return;
+    }
+
+    log::info!("[Updater] Checking for updates ({distribution:?})");
+
+    let update = match app.updater_builder().build() {
+        Ok(updater) => match updater.check().await {
+            Ok(update) => update,
+            Err(error) => {
+                log::warn!("[Updater] Update check failed: {error}");
+                app.dialog()
+                    .message(
+                        i18n::tr("desktop.updater.check_failed_message")
+                            .replace("{0}", &error.to_string()),
+                    )
+                    .title(i18n::tr("desktop.updater.check_failed_title"))
+                    .kind(MessageDialogKind::Error)
+                    .blocking_show();
+                return;
+            }
+        },
+        Err(error) => {
+            log::warn!("[Updater] Failed to initialize updater: {error}");
+            app.dialog()
+                .message(
+                    i18n::tr("desktop.updater.check_failed_message")
+                        .replace("{0}", &error.to_string()),
+                )
+                .title(i18n::tr("desktop.updater.check_failed_title"))
+                .kind(MessageDialogKind::Error)
+                .blocking_show();
+            return;
+        }
+    };
+
+    let Some(update) = update else {
+        log::info!("[Updater] No update available");
+        app.dialog()
+            .message(i18n::tr("desktop.updater.no_updates_message"))
+            .title(i18n::tr("desktop.updater.no_updates_title"))
+            .kind(MessageDialogKind::Info)
+            .blocking_show();
+        return;
+    };
+
+    let should_install = app
+        .dialog()
+        .message(i18n::tr("desktop.updater.available_message").replace("{0}", &update.version))
+        .title(i18n::tr("desktop.updater.available_title"))
+        .kind(MessageDialogKind::Info)
+        .buttons(MessageDialogButtons::YesNo)
+        .blocking_show_with_result()
+        == MessageDialogResult::Yes;
+
+    if !should_install {
+        log::info!("[Updater] User declined update {}", update.version);
+        return;
+    }
+
+    log::info!(
+        "[Updater] Downloading and installing update {}",
+        update.version
+    );
+    match update.download_and_install(|_, _| {}, || {}).await {
+        Ok(()) => {
+            log::info!("[Updater] Update installed; restarting app");
+            app.restart();
+        }
+        Err(error) => {
+            log::warn!("[Updater] Failed to install update: {error}");
+            app.dialog()
+                .message(
+                    i18n::tr("desktop.updater.install_failed_message")
+                        .replace("{0}", &error.to_string()),
+                )
+                .title(i18n::tr("desktop.updater.install_failed_title"))
+                .kind(MessageDialogKind::Error)
+                .blocking_show();
+        }
+    }
 }
 
 #[tauri::command]
@@ -1142,9 +1322,7 @@ pub fn run() {
                     },
                     "update" => {
                         let handle = app.app_handle().clone();
-                        tauri::async_runtime::spawn(async move {
-                            let _ = handle.updater().unwrap().check().await;
-                        });
+                        tauri::async_runtime::spawn(check_for_updates(handle));
                     }
                     "now_playing" => {
                         // Click on now-playing opens the app


### PR DESCRIPTION
This splits the various linux packages into separate jobs, adds support for running our own dedicated flatpak, rpm, and deb repositories using GitHub pages, and fixes the updating for the built-in tauri update mechanism that we use in macOS (outside of home-brew), Windows, and AppImages on Linux. It's difficult to test outside of just doing it, so there may be some quick follow-up PRs and merges if/when I discover problems.

References #125