### PR TITLE
Ensure release exists before package uploads

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -310,6 +310,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
         run: |
-          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
-            gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --notes "Release $RELEASE_TAG"
+          gh release view "$RELEASE_TAG" >/dev/null
           gh release upload "$RELEASE_TAG" "$FLATPAK_BUNDLE" --clobber

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,7 +13,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ensure-release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Ensure GitHub Release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RAW_TAG: ${{ inputs.tag }}
+        run: |
+          TAG="${RAW_TAG#v}"
+          gh release view "$TAG" >/dev/null 2>&1 || \
+            gh release create "$TAG" --target "$GITHUB_SHA" --title "$TAG" --notes "Release $TAG"
+
   build:
+    needs: ensure-release
     permissions:
       contents: write
     uses: ./.github/workflows/build-packages.yml


### PR DESCRIPTION
We had a race condition with multiple actions trying to create the release at once. Centralized, should be fixed.