### PR TITLE
fix(windows): prevent sleep during playback

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,6 +67,7 @@ windows = { version = "0.61", features = [
   "Win32_Media_Audio",
   "Win32_Media_Audio_Endpoints",
   "Win32_System_Com",
+  "Win32_System_Power",
   "Win32_System_Registry",
   "Win32_System_WinRT",
   "Win32_UI_Accessibility",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -453,8 +453,11 @@ async fn navigate_to_launcher(app: tauri::AppHandle) -> Result<(), String> {
     settings::set_string_setting("last_server_name", None)
         .map_err(|e| format!("Failed to clear last_server_name: {}", e))?;
 
-    // Stop Sendspin if running
+    // Stop Sendspin if running and clear any frontend-reported playback state.
+    // This also releases Windows sleep prevention when logging out before the
+    // remote frontend has had a chance to publish its stopped state.
     sendspin::stop().await;
+    now_playing::update_now_playing(NowPlaying::default());
 
     // Find the current window (could be "main" or "launcher" depending on how we got here)
     let old_window = app
@@ -547,6 +550,7 @@ fn start_services(app_handle: tauri::AppHandle) {
             update_tray_now_playing(np);
             media_controls::update(np);
         }));
+        now_playing::init_power_management();
 
         // Get HWND for Windows media controls
         #[cfg(target_os = "windows")]

--- a/src-tauri/src/now_playing.rs
+++ b/src-tauri/src/now_playing.rs
@@ -1,6 +1,90 @@
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex, RwLock};
 
+/// Windows power-management integration for active playback.
+///
+/// `SetThreadExecutionState` is thread-scoped, so playback state changes are
+/// forwarded to a dedicated worker that owns the execution-state assertion.
+#[cfg(target_os = "windows")]
+#[allow(unsafe_code)]
+mod power_management {
+    use super::{get_now_playing, on_now_playing_change};
+    use std::sync::{mpsc, Arc, Once};
+    use std::thread;
+    use windows::Win32::System::Power::{
+        SetThreadExecutionState, ES_CONTINUOUS, ES_SYSTEM_REQUIRED, EXECUTION_STATE,
+    };
+
+    static START: Once = Once::new();
+
+    const ACTIVE_STATE: EXECUTION_STATE = EXECUTION_STATE(ES_CONTINUOUS.0 | ES_SYSTEM_REQUIRED.0);
+    const INACTIVE_STATE: EXECUTION_STATE = EXECUTION_STATE(ES_CONTINUOUS.0);
+
+    pub(super) fn init() {
+        START.call_once(|| {
+            let (tx, rx) = mpsc::channel::<()>();
+            thread::spawn(move || run_worker(rx));
+
+            on_now_playing_change(Arc::new(move |_now_playing| {
+                let _ = tx.send(());
+            }));
+
+            // Playback may have started before desktop services were initialized.
+            let _ = tx.send(());
+        });
+    }
+
+    fn run_worker(rx: mpsc::Receiver<()>) {
+        let mut active = false;
+
+        while rx.recv().is_ok() {
+            // Coalesce metadata/progress updates; only the latest playback state
+            // matters to the power assertion.
+            while rx.try_recv().is_ok() {}
+            let should_prevent_sleep = get_now_playing().is_playing;
+
+            if should_prevent_sleep == active {
+                continue;
+            }
+
+            let state = if should_prevent_sleep {
+                ACTIVE_STATE
+            } else {
+                INACTIVE_STATE
+            };
+            let previous_state = unsafe { SetThreadExecutionState(state) };
+            if previous_state == EXECUTION_STATE(0) {
+                log::warn!(
+                    "[PowerManagement] Failed to {} Windows sleep prevention",
+                    if should_prevent_sleep {
+                        "enable"
+                    } else {
+                        "disable"
+                    }
+                );
+                continue;
+            }
+
+            active = should_prevent_sleep;
+            log::debug!(
+                "[PowerManagement] Windows sleep prevention {}",
+                if active { "enabled" } else { "disabled" }
+            );
+        }
+
+        // Release the assertion if the worker is ever shut down cleanly.
+        if active {
+            let _ = unsafe { SetThreadExecutionState(INACTIVE_STATE) };
+        }
+    }
+}
+
+/// Start the platform-specific playback power-management integration.
+pub fn init_power_management() {
+    #[cfg(target_os = "windows")]
+    power_management::init();
+}
+
 /// Current now-playing information
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NowPlaying {

--- a/src-tauri/src/now_playing.rs
+++ b/src-tauri/src/now_playing.rs
@@ -25,8 +25,9 @@ mod power_management {
             let (tx, rx) = mpsc::channel::<()>();
             thread::spawn(move || run_worker(rx));
 
+            let callback_tx = tx.clone();
             on_now_playing_change(Arc::new(move |_now_playing| {
-                let _ = tx.send(());
+                let _ = callback_tx.send(());
             }));
 
             // Playback may have started before desktop services were initialized.


### PR DESCRIPTION
Tell Windows we need to keep the system awake while playing back. Deliberately do not request that the monitor remain on.

Fixes https://github.com/music-assistant/desktop-app/issues/147 