### PR TITLE
Add about box for all supported platforms

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "enables the default permissions",
-  "windows": ["main"],
+  "windows": ["main", "about"],
   "permissions": [
     "core:default",
     "opener:default",

--- a/src-tauri/resources/about.html
+++ b/src-tauri/resources/about.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About Music Assistant</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      :root,
+      :root.light {
+        --bg-primary: #f5f5f7;
+        --text-primary: #1d1d1f;
+        --text-secondary: #555558;
+        --border-color: #d2d2d7;
+        --accent-color: #007aff;
+        --accent-hover: #0056b3;
+      }
+
+      :root.dark {
+        --bg-primary: #1c1c1e;
+        --text-primary: #f5f5f7;
+        --text-secondary: #aeaeb2;
+        --border-color: #38383a;
+        --accent-color: #0a84ff;
+        --accent-hover: #409cff;
+      }
+
+      html,
+      body {
+        min-height: 100%;
+      }
+
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        padding: 24px;
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+        text-align: center;
+      }
+
+      main {
+        width: 100%;
+        max-width: 320px;
+      }
+
+      .logo {
+        width: 96px;
+        height: 96px;
+        margin-bottom: 18px;
+        border-radius: 20px;
+      }
+
+      h1 {
+        font-size: 22px;
+        font-weight: 600;
+        line-height: 1.25;
+      }
+
+      .website {
+        display: inline-block;
+        margin-top: 9px;
+        color: var(--accent-color);
+        font-size: 13px;
+        line-height: 1.4;
+        user-select: text;
+      }
+
+      .website:hover {
+        color: var(--accent-hover);
+      }
+
+      .website:focus-visible {
+        outline: 2px solid var(--accent-color);
+        outline-offset: 2px;
+      }
+
+      .version {
+        margin-top: 7px;
+        color: var(--text-secondary);
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <img src="logo.png" alt="" class="logo" />
+      <h1 data-i18n="desktop.app.name">Music Assistant</h1>
+      <a
+        class="website"
+        href="https://www.music-assistant.io/"
+        target="_blank"
+        rel="noopener noreferrer"
+        >https://www.music-assistant.io/</a
+      >
+      <div class="version" id="version">Version</div>
+    </main>
+
+    <script src="i18n.js"></script>
+    <script>
+      const invoke = window.__TAURI__?.core?.invoke;
+
+      const colorScheme = window.matchMedia("(prefers-color-scheme: dark)");
+      function applyTheme() {
+        document.documentElement.classList.toggle("dark", colorScheme.matches);
+        document.documentElement.classList.toggle("light", !colorScheme.matches);
+      }
+
+      applyTheme();
+      colorScheme.addEventListener("change", applyTheme);
+
+      if (invoke) {
+        invoke("get_i18n_bundle")
+          .then((bundle) => {
+            initI18n(bundle);
+            applyTranslations();
+          })
+          .then(() => invoke("get_app_version"))
+          .then((version) => {
+            document.getElementById("version").textContent = t("desktop.about.version", version);
+            document.title = t("desktop.mac_menu.about", "Music Assistant");
+          })
+          .catch((error) => console.error("[About] Failed to load details:", error));
+      }
+    </script>
+  </body>
+</html>

--- a/src-tauri/resources/translations/en.json
+++ b/src-tauri/resources/translations/en.json
@@ -19,6 +19,9 @@
       "name": "Music Assistant",
       "settings_title": "Music Assistant - Settings"
     },
+    "about": {
+      "version": "Version {0}"
+    },
     "mac_menu": {
       "about": "About {0}",
       "close_window": "Close Window",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,37 +114,24 @@ fn distribution() -> Distribution {
 
 const RELEASES_URL: &str = "https://github.com/music-assistant/desktop-app/releases/latest";
 const DOCS_URL: &str = "https://music-assistant.io/";
-
 /// Build the macOS menu bar with translated labels.
 #[cfg(target_os = "macos")]
 fn build_macos_menu(app: &tauri::AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
-    use tauri::menu::{AboutMetadata, Menu, SubmenuBuilder, HELP_SUBMENU_ID, WINDOW_SUBMENU_ID};
+    use tauri::menu::{Menu, SubmenuBuilder, HELP_SUBMENU_ID, WINDOW_SUBMENU_ID};
 
-    let pkg_info = app.package_info();
-    let config = app.config();
-    let app_name = pkg_info.name.clone();
-    let about_metadata = AboutMetadata {
-        name: Some(app_name.clone()),
-        version: Some(pkg_info.version.to_string()),
-        copyright: config.bundle.copyright.clone(),
-        authors: config.bundle.publisher.clone().map(|p| vec![p]),
-        ..Default::default()
-    };
+    let app_name = app.package_info().name.clone();
 
     // Labels that embed the app name, e.g. "Quit Music Assistant".
     let named = |key: &str| i18n::tr(key).replace("{0}", &app_name);
     let tr = i18n::tr;
+    let about = MenuItemBuilder::with_id("about", named("desktop.mac_menu.about")).build(app)?;
 
     let preferences = MenuItemBuilder::with_id("app_preferences", tr("desktop.tray.preferences"))
         .accelerator("CmdOrCtrl+,")
         .build(app)?;
 
     let app_menu = SubmenuBuilder::new(app, &*app_name)
-        .item(&PredefinedMenuItem::about(
-            app,
-            Some(&named("desktop.mac_menu.about")),
-            Some(about_metadata),
-        )?)
+        .item(&about)
         .separator()
         .item(&preferences)
         .separator()
@@ -980,6 +967,27 @@ fn strip_hostname_suffix(name: &str) -> String {
         .to_string()
 }
 
+/// Open or focus the dedicated About window.
+fn open_about_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("about") {
+        let _ = window.show();
+        let _ = window.set_focus();
+    } else {
+        let _ = tauri::WebviewWindowBuilder::new(
+            app,
+            "about",
+            tauri::WebviewUrl::App("about.html".into()),
+        )
+        .title(i18n::tr("desktop.mac_menu.about").replace("{0}", &app.package_info().name))
+        .inner_size(320.0, 280.0)
+        .resizable(false)
+        .maximizable(false)
+        .minimizable(false)
+        .center()
+        .build();
+    }
+}
+
 /// Open or focus the companion app's settings window.
 fn open_settings_window(app: &tauri::AppHandle) {
     if let Some(window) = app.get_webview_window("settings") {
@@ -1228,7 +1236,7 @@ pub fn run() {
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                if settings::get_settings().close_to_tray {
+                if window.label() == "main" && settings::get_settings().close_to_tray {
                     if let Ok(pos) = window.outer_position() {
                         stash_window_position(pos);
                     }
@@ -1347,6 +1355,14 @@ pub fn run() {
                 i18n::tr("desktop.tray.open_log_file"),
             )
             .build(app)?;
+            let about = MenuItemBuilder::with_id(
+                "tray_about",
+                i18n::tr("desktop.mac_menu.about").replace(
+                    "{0}",
+                    &app.package_info().name,
+                ),
+            )
+            .build(app)?;
             let separator4 = PredefinedMenuItem::separator(app)?;
             let quit = MenuItemBuilder::with_id("quit", i18n::tr("common.actions.quit")).build(app)?;
 
@@ -1385,6 +1401,7 @@ pub fn run() {
                     &update,
                     &relaunch,
                     &open_log,
+                    &about,
                     &separator4,
                     &quit,
                 ])
@@ -1518,6 +1535,7 @@ pub fn run() {
                     "relaunch" => {
                         tauri::process::restart(&app.env());
                     }
+                    "tray_about" => open_about_window(app),
                     "open_log" => match app.path().app_log_dir() {
                         Ok(log_dir) => {
                             let log_file =
@@ -1603,6 +1621,7 @@ pub fn run() {
             app.on_menu_event(move |app, event| {
                 match event.id().as_ref() {
                     "app_preferences" => open_settings_window(app),
+                    "about" => open_about_window(app),
                     "help_docs" => {
                         if let Err(error) = app.opener().open_url(DOCS_URL, None::<&str>) {
                             log::warn!("[App] Failed to open documentation: {error}");


### PR DESCRIPTION
Reachable through the menubar/taskbar menu for platforms without natives app menus. 

Added a link to the Music Assistant website.

Closes #140 