### PR TITLE
Keep Linux and Windows tray icons visible

### DIFF
--- a/src-tauri/resources/settings.html
+++ b/src-tauri/resources/settings.html
@@ -380,7 +380,7 @@
           />
           <label for="autostart-toggle" class="toggle-label"></label>
         </div>
-        <div class="setting-item">
+        <div class="setting-item" id="tray-visibility-setting">
           <div class="setting-label">
             <label for="tray-toggle" data-i18n="desktop.settings.show_menubar_icon">
               Show menubar icon
@@ -984,6 +984,8 @@
           const settings = await invoke("get_settings");
           const trayIconThemeSetting = document.getElementById("tray-icon-theme-setting");
           trayIconThemeSetting.hidden = !(await invoke("is_linux"));
+          const trayVisibilitySetting = document.getElementById("tray-visibility-setting");
+          trayVisibilitySetting.hidden = !(await invoke("is_macos"));
 
           document.getElementById("discord-toggle").checked = settings.discord_rpc_enabled === true;
           document.getElementById("minimized-toggle").checked = settings.start_minimized === true;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,6 +73,11 @@ fn is_linux() -> bool {
     cfg!(target_os = "linux")
 }
 
+#[tauri::command]
+fn is_macos() -> bool {
+    cfg!(target_os = "macos")
+}
+
 /// Get the app version
 ///
 /// Sourced from the Tauri config (`tauri.conf.json`) via `package_info`, which the
@@ -1229,6 +1234,7 @@ pub fn run() {
             is_companion_app,
             is_desktop_app,
             is_linux,
+            is_macos,
             get_app_version,
             get_i18n_bundle,
             server_connecting,
@@ -1610,7 +1616,9 @@ pub fn run() {
                 *tray_guard = Some(tray);
             }
 
-            // Apply initial tray visibility from settings
+            // macOS can hide its menu bar icon; Linux and Windows always keep
+            // the tray icon available as the only settings entry point.
+            #[cfg(target_os = "macos")]
             if !loaded_settings.show_tray_icon {
                 set_tray_visible(false);
             }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -474,8 +474,10 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     #[test]
     fn non_macos_normalizes_tray_icon_to_visible() {
-        let mut settings = Settings::default();
-        settings.show_tray_icon = false;
+        let settings = Settings {
+            show_tray_icon: false,
+            ..Settings::default()
+        };
         assert!(normalize_platform_settings(settings).show_tray_icon);
     }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -94,6 +94,20 @@ fn default_show_tray_icon() -> bool {
     true
 }
 
+fn normalize_platform_settings(settings: Settings) -> Settings {
+    // Linux and Windows do not have an application menu or in-app chrome that
+    // provides another reliable route to the settings window.
+    #[cfg(not(target_os = "macos"))]
+    {
+        let mut settings = settings;
+        settings.show_tray_icon = true;
+        settings
+    }
+
+    #[cfg(target_os = "macos")]
+    settings
+}
+
 fn default_player_name() -> String {
     // Use system hostname as default player name, stripped of common suffixes
     hostname::get()
@@ -176,6 +190,8 @@ pub fn load_settings() -> Settings {
         Settings::default()
     };
 
+    settings = normalize_platform_settings(settings);
+
     if !settings.debug_logging {
         settings.trace_logging = false;
     }
@@ -255,8 +271,16 @@ pub fn set_setting(app: tauri::AppHandle, key: &str, value: bool) -> Result<(), 
             }
         }
         "show_tray_icon" => {
-            settings.show_tray_icon = value;
-            crate::set_tray_visible(value);
+            #[cfg(target_os = "macos")]
+            {
+                settings.show_tray_icon = value;
+                crate::set_tray_visible(value);
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                settings.show_tray_icon = true;
+                crate::set_tray_visible(true);
+            }
         }
         "show_tray_now_playing" => {
             settings.show_tray_now_playing = value;
@@ -445,6 +469,14 @@ mod tests {
     #[test]
     fn volume_control_mode_default_is_auto() {
         assert_eq!(VolumeControlMode::default(), VolumeControlMode::Auto);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn non_macos_normalizes_tray_icon_to_visible() {
+        let mut settings = Settings::default();
+        settings.show_tray_icon = false;
+        assert!(normalize_platform_settings(settings).show_tray_icon);
     }
 
     #[test]


### PR DESCRIPTION
We do not have any native UI to open the settings window on Linux or Windows, if the tray/menu icon is hidden. Remove the footgun that lets folks turn that off with no way to fix it outside of manually editing their config file.