### PR TITLE
fix: align Linux MPRIS application identity

### DIFF
--- a/music-assistant.desktop
+++ b/music-assistant.desktop
@@ -2,7 +2,7 @@
 Categories=Music
 Comment=Music Assistant Desktop App
 Exec=music-assistant-companion
-Icon=music-assistant
+Icon=music-assistant-companion
 Name=Music Assistant
 Terminal=false
 Type=Application

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -59,10 +59,9 @@ the installed application ID is always `io.music_assistant.Companion`.
   manifest installs resources under `/app/lib/Music Assistant/resources`.
 - The current Linux app code forces `GDK_BACKEND=x11` for tray stability, so the
   manifest grants X11 rather than Wayland-only access.
-- MPRIS currently owns `org.mpris.MediaPlayer2.music_assistant.*`; the manifest
-  grants that name explicitly. If the app later changes its MPRIS name to
-  `org.mpris.MediaPlayer2.io.music_assistant.Companion`, the explicit
-  `--own-name` can be removed because Flatpak permits that pattern by default.
+- MPRIS owns `org.mpris.MediaPlayer2.io_music_assistant_companion.instance<PID>`.
+  The manifest grants the transformed MPRIS namespace explicitly because the
+  MPRIS name uses the D-Bus-safe underscore form of the Tauri identifier.
 - The Tauri single-instance plugin uses the configured identifier
   `io.music-assistant.companion`, transformed to the D-Bus name
   `org.io_music_assistant_companion.SingleInstance`, so the manifest grants

--- a/packaging/flatpak/io.music_assistant.Companion.yml
+++ b/packaging/flatpak/io.music_assistant.Companion.yml
@@ -27,9 +27,9 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --filesystem=xdg-run/tray-icon:create
 
-  # MPRIS media controls. Flatpak permits org.mpris.MediaPlayer2.$FLATPAK_ID by
-  # default, but the existing Linux backend owns org.mpris.MediaPlayer2.music_assistant.*.
-  - --own-name=org.mpris.MediaPlayer2.music_assistant.*
+  # MPRIS media controls. The Linux backend uses the D-Bus-safe underscore form
+  # of the canonical application ID and appends a per-instance suffix.
+  - --own-name=org.mpris.MediaPlayer2.io_music_assistant_companion.*
 
   # Tauri single-instance uses tauri.conf.json's identifier, transformed for D-Bus.
   # `own` is the highest D-Bus policy level and includes talking to the name;

--- a/src-tauri/src/media_controls/linux.rs
+++ b/src-tauri/src/media_controls/linux.rs
@@ -1,8 +1,8 @@
 //! Native Linux MPRIS media-controls backend over zbus.
 //!
-//! Registers `org.mpris.MediaPlayer2.music_assistant.instance<PID>` at the
-//! standard `/org/mpris/MediaPlayer2` path, sharing the playback-state mapping
-//! in [`super::plan`] with the macOS backend.
+//! Registers `org.mpris.MediaPlayer2.io_music_assistant_companion.instance<PID>`
+//! at the standard `/org/mpris/MediaPlayer2` path, sharing the playback-state
+//! mapping in [`super::plan`] with the macOS backend.
 
 use super::{plan, MediaControlCallback, PlaybackState};
 use crate::now_playing::NowPlaying;
@@ -18,10 +18,16 @@ use zbus::object_server::SignalEmitter;
 use zbus::zvariant::{ObjectPath, OwnedValue, Value};
 use zbus::{connection, interface};
 
-const BUS_NAME_BASE: &str = "org.mpris.MediaPlayer2.music_assistant";
+const BUS_NAME_BASE: &str = "org.mpris.MediaPlayer2.io_music_assistant_companion";
 const OBJECT_PATH: &str = "/org/mpris/MediaPlayer2";
-const DESKTOP_ENTRY: &str = "music-assistant";
 const IDENTITY: &str = "Music Assistant";
+
+fn desktop_entry() -> &'static str {
+    match option_env!("MUSIC_ASSISTANT_DISTRIBUTION") {
+        Some("flatpak") => "io.music_assistant.Companion",
+        _ => "Music Assistant",
+    }
+}
 const PLAYER_IFACE: &str = "org.mpris.MediaPlayer2.Player";
 
 static SERVICE_TX: Mutex<Option<UnboundedSender<ServiceCommand>>> = Mutex::new(None);
@@ -378,7 +384,7 @@ impl MediaPlayer2Root {
 
     #[zbus(property)]
     fn desktop_entry(&self) -> &str {
-        DESKTOP_ENTRY
+        desktop_entry()
     }
 
     #[zbus(property)]
@@ -535,6 +541,19 @@ impl MediaPlayer2Player {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_linux_identity_matches_packaging() {
+        assert_eq!(
+            BUS_NAME_BASE,
+            "org.mpris.MediaPlayer2.io_music_assistant_companion"
+        );
+        let expected_desktop_entry = match option_env!("MUSIC_ASSISTANT_DISTRIBUTION") {
+            Some("flatpak") => "io.music_assistant.Companion",
+            _ => "Music Assistant",
+        };
+        assert_eq!(desktop_entry(), expected_desktop_entry);
+    }
 
     #[test]
     fn stopped_without_track_has_stopped_status() {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -437,7 +437,8 @@ fn set_flatpak_autostart(enabled: bool) -> std::io::Result<()> {
 
     // In a Flatpak sandbox, XDG_CONFIG_HOME points at the app-private config
     // dir. The manifest grants `xdg-config/autostart:create`, so write through
-    // $HOME/.config/autostart to reach the host XDG autostart directory.
+    // $HOME/.config/autostart to reach the host XDG autostart directory using
+    // the canonical application desktop-entry ID.
     let autostart_dir = dirs::home_dir()
         .ok_or_else(|| std::io::Error::other("Could not determine home directory"))?
         .join(".config")


### PR DESCRIPTION
Flatpak works differently than everything else and it broke MPRIS. This should fix that, at least it does in my test VM.