### PR TITLE
fix(sendspin): advertise 24-bit on macOS (cpal reports F32, not I24)

### DIFF
--- a/src-tauri/src/sendspin/devices.rs
+++ b/src-tauri/src/sendspin/devices.rs
@@ -364,11 +364,27 @@ fn sort_key(f: SupportedPcmFormat, native_rate: Option<u32>) -> (u32, u32, u32, 
 
 /// Whether a cpal sample format can carry 24-bit PCM content.
 ///
-/// Currently limited to the explicit 24-bit integer formats. Broader
-/// detection — F32/F64/I32/U32/I64/U64 all carry at least 24 bits of
-/// precision and so could safely advertise 24-bit — is a follow-up.
+/// Anything with at least 24 bits of precision qualifies, not just the explicit
+/// 24-bit integer formats. This matters on `CoreAudio`, where cpal reports F32 for
+/// every output device — so restricting the check to I24/U24 meant no macOS
+/// device ever advertised 24-bit, however capable the hardware was.
+///
+/// F32 has a 24-bit mantissa, so it carries a 24-bit sample exactly; the wider
+/// integer and F64 formats have headroom to spare. DSD formats are excluded:
+/// they are 1-bit sigma-delta bitstreams, not PCM, and the playback path only
+/// handles PCM.
 fn sample_format_supports_24bit(fmt: cpal::SampleFormat) -> bool {
-    matches!(fmt, cpal::SampleFormat::I24 | cpal::SampleFormat::U24)
+    matches!(
+        fmt,
+        cpal::SampleFormat::I24
+            | cpal::SampleFormat::U24
+            | cpal::SampleFormat::I32
+            | cpal::SampleFormat::U32
+            | cpal::SampleFormat::I64
+            | cpal::SampleFormat::U64
+            | cpal::SampleFormat::F32
+            | cpal::SampleFormat::F64
+    )
 }
 
 #[cfg(test)]
@@ -526,6 +542,55 @@ mod tests {
         assert!(!sample_format_supports_24bit(cpal::SampleFormat::U8));
         assert!(!sample_format_supports_24bit(cpal::SampleFormat::I16));
         assert!(!sample_format_supports_24bit(cpal::SampleFormat::U16));
+    }
+
+    #[test]
+    fn sample_format_supports_24bit_includes_wider_formats() {
+        // F32 is the one that matters in practice: it is what cpal reports for
+        // every output device on CoreAudio, so excluding it meant no macOS
+        // device could ever advertise 24-bit.
+        assert!(sample_format_supports_24bit(cpal::SampleFormat::F32));
+        assert!(sample_format_supports_24bit(cpal::SampleFormat::F64));
+        assert!(sample_format_supports_24bit(cpal::SampleFormat::I32));
+        assert!(sample_format_supports_24bit(cpal::SampleFormat::U32));
+        assert!(sample_format_supports_24bit(cpal::SampleFormat::I64));
+        assert!(sample_format_supports_24bit(cpal::SampleFormat::U64));
+    }
+
+    #[test]
+    fn sample_format_supports_24bit_excludes_dsd_formats() {
+        // DSD is a 1-bit sigma-delta bitstream, not PCM. The playback path
+        // rejects anything that is not 16- or 24-bit PCM, so advertising
+        // 24-bit for a DSD-only config would promise a stream it cannot open.
+        assert!(!sample_format_supports_24bit(cpal::SampleFormat::DsdU8));
+        assert!(!sample_format_supports_24bit(cpal::SampleFormat::DsdU16));
+        assert!(!sample_format_supports_24bit(cpal::SampleFormat::DsdU32));
+    }
+
+    #[test]
+    fn build_formats_advertises_24bit_for_a_coreaudio_style_f32_device() {
+        // Regression test for the macOS case: an F32-only device that supports
+        // 24-bit hardware must still get a 24-bit entry at its native rate.
+        let caps = DeviceCapabilities {
+            native: Some(NativeFormat {
+                channels: 2,
+                sample_rate: 96_000,
+                supports_24bit: sample_format_supports_24bit(cpal::SampleFormat::F32),
+            }),
+            ranges: vec![],
+        };
+        let formats = build_formats(&caps);
+        assert!(
+            formats
+                .iter()
+                .any(|f| f.bit_depth == 24 && f.sample_rate == 96_000),
+            "expected a 24-bit entry at the native rate, got {formats:?}"
+        );
+        assert_eq!(
+            formats.first().map(|f| f.bit_depth),
+            Some(24),
+            "24-bit must rank first at the native rate"
+        );
     }
 
     // ---- derive_supported_pcm_formats (entry point) ----------------------


### PR DESCRIPTION
I have a DragonFly Red on my MacBook Pro (M1 Pro) and noticed the app was only ever giving me 16-bit output, even with a 24-bit/192kHz source and the DAC set to 24-bit in Audio MIDI Setup. Turns out the Sendspin client never advertises 24-bit on macOS at all.

The cause is `sample_format_supports_24bit()` in `src-tauri/src/sendspin/devices.rs`. It only matches `I24`/`U24`, but on CoreAudio cpal reports `F32` for every output device. Since `build_formats()` gates every 24-bit entry on that flag, the advertised list collapses to 16-bit only.

I wrote a small cpal probe to see what my machine actually reports:

```
=== device "AudioQuest DragonFly Red v1.0"
  default: fmt=F32 rate=96000 ch=2
  supported: fmt=F32 ch=2 rate=44100..44100
  supported: fmt=F32 ch=2 rate=48000..48000
  supported: fmt=F32 ch=2 rate=88200..88200
  supported: fmt=F32 ch=2 rate=96000..96000

=== device "MacBook Pro Speakers"
  default: fmt=F32 rate=44100 ch=2
  supported: fmt=F32 ch=2 rate=44100..44100
  ...
```

F32 everywhere, so today the 24-bit branch is effectively dead code on macOS.

And this is what the server ended up offering me before the change ("Preferred audio format" in the player settings):

```
automatic
pcm:96000:16:2
pcm:48000:16:2
pcm:44100:16:2
```

96000 is the native anchor and also my DAC's maximum, so the rate detection is working correctly — it's only the bit depth that is stuck.

The comment already on that function proposed exactly this fix, so I've just done it: `F32`/`F64`/`I32`/`U32`/`I64`/`U64` all carry at least 24 bits of precision. F32 has a 24-bit mantissa, so a 24-bit sample fits in it exactly.

I left DSD out on purpose (`DsdU8`/`DsdU16`/`DsdU32`). Those are 1-bit sigma-delta bitstreams rather than PCM, and the playback path only accepts 16- or 24-bit PCM, so advertising 24-bit for a DSD-only config would promise a stream it can't actually open.

Nothing else needed changing. The playback side already handles 24-bit — `matches!(fmt.bit_depth, 16 | 24)` when the stream starts, and `24 => 3` bytes per sample when decoding.

### Tests

Extended the existing `sample_format_supports_24bit` cases to cover the wider formats and DSD, and added a `build_formats` test that derives `supports_24bit` from `F32` instead of hardcoding `true`, so the macOS path can't quietly regress again.

`cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` both clean.

### Tested on

macOS (M1 Pro, arm64), AudioQuest DragonFly Red, streaming 24-bit/192kHz ALAC from Apple Music through Music Assistant.
