### PR TITLE
fix: align the media-controls backends with their OS contracts

### DIFF
--- a/packaging/flatpak/io.music_assistant.Companion.yml
+++ b/packaging/flatpak/io.music_assistant.Companion.yml
@@ -137,6 +137,10 @@ modules:
         sources:
           - type: archive
             url: https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.114.tar.gz
+            # Byte-identical upstream tarball; dbus.freedesktop.org has a
+            # history of extended outages that otherwise fail every cold build.
+            mirror-urls:
+              - https://deb.debian.org/debian/pool/main/d/dbus-glib/dbus-glib_0.114.orig.tar.gz
             sha256: c09c5c085b2a0e391b8ee7d783a1d63fe444e96717cc1814d61b5e8fc2827a7c
 
       - name: libdbusmenu

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -450,12 +450,51 @@ async fn navigate_to_launcher(app: tauri::AppHandle) -> Result<(), String> {
     let _ = new_window.show();
     let _ = new_window.set_focus();
 
+    // Windows media controls are bound to the old window's HWND, which is
+    // about to be destroyed; re-bind them to the replacement.
+    #[cfg(target_os = "windows")]
+    media_controls::rebind(window_hwnd(&new_window));
+
     // Now close the old window
     if let Some(old) = old_window {
         let _ = old.destroy();
     }
 
     Ok(())
+}
+
+/// Extract the Win32 HWND from a webview window for media-controls binding.
+#[cfg(target_os = "windows")]
+fn window_hwnd(window: &tauri::WebviewWindow) -> Option<*mut std::ffi::c_void> {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    window.window_handle().ok().and_then(|handle| {
+        if let RawWindowHandle::Win32(win32_handle) = handle.as_ref() {
+            Some(win32_handle.hwnd.get() as *mut std::ffi::c_void)
+        } else {
+            None
+        }
+    })
+}
+
+/// Show and focus the main application window (used by the Linux MPRIS
+/// `Raise` method, invoked when the user clicks the desktop's media widget).
+/// Window operations are marshalled to the main thread: on Linux, GTK window
+/// calls are not safe from arbitrary threads (here: the zbus service thread).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(crate) fn raise_main_window() {
+    if let Some(app) = APP_HANDLE.lock().unwrap().clone() {
+        let handle = app.clone();
+        let _ = app.run_on_main_thread(move || {
+            if let Some(window) = handle
+                .get_webview_window("main")
+                .or_else(|| handle.get_webview_window("launcher"))
+            {
+                let _ = window.unminimize();
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+        });
+    }
 }
 
 /// Get current now-playing information
@@ -520,20 +559,10 @@ fn start_services(app_handle: tauri::AppHandle) {
         #[cfg(target_os = "windows")]
         let hwnd = {
             if let Some(ref app) = *APP_HANDLE.lock().unwrap() {
-                if let Some(window) = app.get_webview_window("main")
-                    .or_else(|| app.get_webview_window("launcher")) {
-                    // Get the HWND from the window
-                    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-                    window.window_handle().ok().and_then(|handle| {
-                        if let RawWindowHandle::Win32(win32_handle) = handle.as_ref() {
-                            Some(win32_handle.hwnd.get() as *mut std::ffi::c_void)
-                        } else {
-                            None
-                        }
-                    })
-                } else {
-                    None
-                }
+                app.get_webview_window("main")
+                    .or_else(|| app.get_webview_window("launcher"))
+                    .as_ref()
+                    .and_then(window_hwnd)
             } else {
                 None
             }
@@ -556,8 +585,9 @@ fn start_services(app_handle: tauri::AppHandle) {
 
         // Initialize media controls with callback for control events
         media_controls::init(Arc::new(|command| {
-            // Route media control events (from OS Now Playing / media keys) to frontend
-            log::debug!("[MediaControls] OS media command: {command}");
+            // Info-level: this is the only trace at default log levels that an
+            // OS media-key / widget press reached the app at all.
+            log::info!("[MediaControls] OS media command: {command}");
             if let Some(ref app) = *APP_HANDLE.lock().unwrap() {
                 if let Some(window) = app.get_webview_window("main")
                     .or_else(|| app.get_webview_window("launcher")) {
@@ -1508,6 +1538,11 @@ pub fn run() {
                         .build() {
                             let _ = new_window.show();
                             let _ = new_window.set_focus();
+
+                            // Re-bind Windows media controls before the old
+                            // window (their current HWND) is destroyed.
+                            #[cfg(target_os = "windows")]
+                            media_controls::rebind(window_hwnd(&new_window));
 
                             // Now close the old window
                             if let Some(old) = old_window {

--- a/src-tauri/src/media_controls/linux.rs
+++ b/src-tauri/src/media_controls/linux.rs
@@ -11,6 +11,7 @@ use parking_lot::Mutex;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
+use std::time::Instant;
 use tokio::sync::mpsc::{self, UnboundedSender};
 use zbus::fdo;
 use zbus::names::InterfaceName;
@@ -22,6 +23,17 @@ const BUS_NAME_BASE: &str = "org.mpris.MediaPlayer2.io_music_assistant_companion
 const OBJECT_PATH: &str = "/org/mpris/MediaPlayer2";
 const IDENTITY: &str = "Music Assistant";
 
+/// How far a freshly reported position may deviate from the extrapolated one
+/// before it counts as a seek (and must be announced via the `Seeked` signal)
+/// rather than normal playback progression. Upstream position reports jitter
+/// by over a second around play/pause transitions, so the threshold must
+/// comfortably exceed that; genuine seeks jump by far more.
+const SEEK_JUMP_THRESHOLD_US: i64 = 2_000_000;
+
+/// Basename (without `.desktop`) of the installed desktop file, per bundle:
+/// the flatpak manifest installs `io.music_assistant.Companion.desktop`, while
+/// tauri-bundler (deb/rpm/AppImage) names the file after `productName` —
+/// literally `Music Assistant.desktop`, space included.
 fn desktop_entry() -> &'static str {
     match option_env!("MUSIC_ASSISTANT_DISTRIBUTION") {
         Some("flatpak") => "io.music_assistant.Companion",
@@ -31,6 +43,19 @@ fn desktop_entry() -> &'static str {
 const PLAYER_IFACE: &str = "org.mpris.MediaPlayer2.Player";
 
 static SERVICE_TX: Mutex<Option<UnboundedSender<ServiceCommand>>> = Mutex::new(None);
+
+/// Last volume observed or requested, as an MPRIS `Volume` value; `None`
+/// until first seeded.
+///
+/// Written only by the sendspin volume listener, an optimistic `SetVolume`
+/// write, and a one-time seed from the live sendspin snapshot. The getter
+/// must never overwrite it from the live snapshot: zbus re-reads the getter
+/// to build the automatic `PropertiesChanged` after a property set, and
+/// sendspin applies volume asynchronously, so a getter-side overwrite would
+/// re-emit the stale value (volume-slider snap-back). Never reset, not even
+/// on disconnect: an unseeded getter falls back to full volume, which is
+/// worse than briefly reporting the previous player's level.
+static LAST_VOLUME: Mutex<Option<f64>> = Mutex::new(None);
 
 #[derive(Debug)]
 enum ServiceCommand {
@@ -67,6 +92,7 @@ pub fn init(callback: MediaControlCallback, _hwnd_param: Option<*mut std::ffi::c
             Ok(runtime) => runtime,
             Err(e) => {
                 log::error!("[MediaControls] Failed to create Linux MPRIS runtime: {e}");
+                *SERVICE_TX.lock() = None;
                 return;
             }
         };
@@ -74,6 +100,11 @@ pub fn init(callback: MediaControlCallback, _hwnd_param: Option<*mut std::ffi::c
         if let Err(e) = runtime.block_on(run_service(bus_name, callback, rx)) {
             log::error!("[MediaControls] Linux MPRIS service stopped: {e}");
         }
+
+        // The receiver is gone (bus-name acquisition failed, no session bus,
+        // …); drop the sender too so subsequent updates become cheap no-ops
+        // instead of a per-tick send-error warning against a closed channel.
+        *SERVICE_TX.lock() = None;
     });
 }
 
@@ -118,22 +149,49 @@ async fn run_service(
         PLAYER_IFACE.try_into().expect("valid interface name");
     log::info!("[MediaControls] Linux MPRIS service registered as {bus_name}");
 
+    // The last snapshot whose properties were emitted; lets updates emit only
+    // the properties that actually changed instead of the full fixed set on
+    // every progress tick.
+    let mut last_emitted: Option<EmittedProperties> = None;
+
     // Async channel keeps the runtime cooperative between updates so inbound
     // method calls (Next/Play/…) are serviced even while idle.
     while let Some(command) = rx.recv().await {
         match command {
             ServiceCommand::Update(np) => {
+                let now = Instant::now();
+                let previous = shared.snapshot();
                 shared.update(np);
-                emit_player_properties(&emitter, &player_iface, &shared).await;
+                let current = shared.snapshot();
+
+                // Properties (Metadata in particular) go out first: on a
+                // track change clients reset their position when they see the
+                // new trackid, so a Seeked sent before the Metadata change
+                // would be applied to the old track and then discarded.
+                emit_player_properties(&emitter, &player_iface, &current, &mut last_emitted).await;
+
+                // Clients extrapolate Position from the last read value and
+                // Rate; any jump inconsistent with that must be announced.
+                if let Some(position) = seek_jump(&previous, &current, now) {
+                    if let Err(e) = MediaPlayer2Player::seeked(&emitter, position).await {
+                        log::warn!("[MediaControls] Failed to emit Linux MPRIS Seeked: {e}");
+                    }
+                }
             }
             ServiceCommand::Clear => {
                 shared.clear();
-                emit_player_properties(&emitter, &player_iface, &shared).await;
+                let current = shared.snapshot();
+                emit_player_properties(&emitter, &player_iface, &current, &mut last_emitted).await;
             }
             ServiceCommand::VolumeChanged(volume) => {
-                let changed =
-                    HashMap::from([("Volume", Value::from(percent_to_mpris_volume(volume)))]);
-                emit_properties_changed(&emitter, &player_iface, changed).await;
+                let volume = percent_to_mpris_volume(volume);
+                *LAST_VOLUME.lock() = Some(volume);
+                let changed = HashMap::from([("Volume", Value::from(volume))]);
+                if emit_properties_changed(&emitter, &player_iface, changed).await {
+                    if let Some(last) = last_emitted.as_mut() {
+                        last.volume = volume;
+                    }
+                }
             }
         }
     }
@@ -141,32 +199,81 @@ async fn run_service(
     Ok(())
 }
 
+/// The property values included in the previous `PropertiesChanged` emission,
+/// used to emit only deltas on subsequent updates.
+struct EmittedProperties {
+    state: MprisState,
+    volume: f64,
+}
+
+/// The properties whose current values differ from the previously emitted
+/// ones. Pure so the delta logic is unit-testable; `None` for `last` (first
+/// emission) yields the full set.
+///
+/// `Position` is omitted on purpose: the spec says clients must track it via
+/// Rate-based extrapolation plus the Seeked signal, never through
+/// `PropertiesChanged`. Everything else on the interface is constant.
+fn changed_properties(
+    last: Option<&EmittedProperties>,
+    snapshot: &MprisState,
+    volume: f64,
+) -> HashMap<&'static str, Value<'static>> {
+    let mut changed: HashMap<&'static str, Value<'static>> = HashMap::new();
+
+    if last.is_none_or(|l| l.state.playback_status != snapshot.playback_status) {
+        changed.insert("PlaybackStatus", Value::from(snapshot.playback_status()));
+    }
+    if last.is_none_or(|l| !l.state.same_metadata(snapshot)) {
+        changed.insert("Metadata", Value::from(snapshot.metadata()));
+    }
+    if last.is_none_or(|l| l.state.can_play != snapshot.can_play) {
+        changed.insert("CanPlay", Value::from(snapshot.can_play));
+    }
+    if last.is_none_or(|l| l.state.can_pause != snapshot.can_pause) {
+        changed.insert("CanPause", Value::from(snapshot.can_pause));
+    }
+    if last.is_none_or(|l| l.state.can_next != snapshot.can_next) {
+        changed.insert("CanGoNext", Value::from(snapshot.can_next));
+    }
+    if last.is_none_or(|l| l.state.can_previous != snapshot.can_previous) {
+        changed.insert("CanGoPrevious", Value::from(snapshot.can_previous));
+    }
+    // Bit-exact comparison on purpose: this deduplicates emissions of the
+    // same stored value, not a numeric tolerance check.
+    if last.is_none_or(|l| l.volume.to_bits() != volume.to_bits()) {
+        changed.insert("Volume", Value::from(volume));
+    }
+
+    changed
+}
+
 async fn emit_player_properties(
     emitter: &SignalEmitter<'static>,
     interface: &InterfaceName<'static>,
-    state: &SharedState,
+    snapshot: &MprisState,
+    last_emitted: &mut Option<EmittedProperties>,
 ) {
-    let snapshot = state.snapshot();
-    let mut changed: HashMap<&str, Value<'_>> = HashMap::new();
-    changed.insert("PlaybackStatus", Value::from(snapshot.playback_status()));
-    changed.insert("Metadata", Value::from(snapshot.metadata()));
-    changed.insert("CanPlay", Value::from(snapshot.can_play));
-    changed.insert("CanPause", Value::from(snapshot.can_pause));
-    changed.insert("CanGoNext", Value::from(snapshot.can_next));
-    changed.insert("CanGoPrevious", Value::from(snapshot.can_previous));
-    changed.insert("Volume", Value::from(current_mpris_volume()));
+    let volume = current_mpris_volume();
+    let changed = changed_properties(last_emitted.as_ref(), snapshot, volume);
 
-    // `Position` is omitted on purpose: the spec says clients should track it
-    // via the Seeked signal, and CanSeek is false here.
-    emit_properties_changed(emitter, interface, changed).await;
+    // Advance the ledger only after a successful emission (or when there was
+    // nothing to say), so a transient D-Bus failure is retried on the next
+    // update instead of being permanently suppressed for that value.
+    if changed.is_empty() || emit_properties_changed(emitter, interface, changed).await {
+        *last_emitted = Some(EmittedProperties {
+            state: snapshot.clone(),
+            volume,
+        });
+    }
 }
 
+/// Returns whether the emission succeeded.
 async fn emit_properties_changed(
     emitter: &SignalEmitter<'static>,
     interface: &InterfaceName<'static>,
     changed: HashMap<&str, Value<'_>>,
-) {
-    if let Err(e) = fdo::Properties::properties_changed(
+) -> bool {
+    match fdo::Properties::properties_changed(
         emitter,
         interface.clone(),
         changed,
@@ -174,7 +281,47 @@ async fn emit_properties_changed(
     )
     .await
     {
-        log::warn!("[MediaControls] Failed to emit Linux MPRIS property change: {e}");
+        Ok(()) => true,
+        Err(e) => {
+            log::warn!("[MediaControls] Failed to emit Linux MPRIS property change: {e}");
+            false
+        }
+    }
+}
+
+/// Decide whether the transition `previous` -> `current` constitutes a seek
+/// that must be announced with the `Seeked` signal, and if so at what position.
+///
+/// Same track: any deviation beyond [`SEEK_JUMP_THRESHOLD_US`] from the
+/// position clients extrapolate on their own. New track: only a start away
+/// from 0 (clients reset their position on a Metadata/trackid change).
+fn seek_jump(previous: &MprisState, current: &MprisState, now: Instant) -> Option<i64> {
+    current.track.as_ref()?;
+
+    let new_position = current.position_at(now);
+    let same_track = previous.track.is_some()
+        && previous.track == current.track
+        && previous.artist == current.artist
+        && previous.album == current.album;
+
+    if same_track {
+        let extrapolated = previous.position_at(now);
+        let deviation = if previous.playback_status == current.playback_status {
+            (new_position - extrapolated).abs()
+        } else {
+            // Across a play/pause transition the reported position lags the
+            // extrapolation by the upstream update latency. Only call it a
+            // seek when the jump is inconsistent with BOTH the extrapolated
+            // and the frozen last-reported position — a plain pause/resume is
+            // near one of them, a genuine seek is far from both.
+            let frozen = previous.position_us;
+            (new_position - extrapolated)
+                .abs()
+                .min((new_position - frozen).abs())
+        };
+        (deviation > SEEK_JUMP_THRESHOLD_US).then_some(new_position)
+    } else {
+        (new_position > SEEK_JUMP_THRESHOLD_US).then_some(new_position)
     }
 }
 
@@ -187,7 +334,7 @@ impl SharedState {
     }
 
     fn update(&self, np: NowPlaying) {
-        *self.0.lock() = MprisState::from_now_playing(&np);
+        *self.0.lock() = MprisState::from_now_playing(&np, Instant::now());
     }
 
     fn clear(&self) {
@@ -203,7 +350,10 @@ struct MprisState {
     album: Option<String>,
     art_url: Option<String>,
     length_us: Option<i64>,
+    /// Position reported by the last update, valid as of `updated_at`.
     position_us: i64,
+    /// When `position_us` was captured; `None` only for the default state.
+    updated_at: Option<Instant>,
     can_play: bool,
     can_pause: bool,
     can_next: bool,
@@ -211,8 +361,9 @@ struct MprisState {
 }
 
 impl MprisState {
-    fn from_now_playing(np: &NowPlaying) -> Self {
-        // Delegate the shared mapping to super::plan so it stays consistent with macOS.
+    fn from_now_playing(np: &NowPlaying, now: Instant) -> Self {
+        // super::plan owns the mapping shared with the other backends,
+        // including the state-independent CanPlay/CanPause semantics.
         let plan = plan(np);
 
         Self {
@@ -223,8 +374,9 @@ impl MprisState {
             art_url: plan.image_url,
             length_us: plan.duration_secs.map(seconds_to_microseconds),
             position_us: plan.elapsed_secs.map_or(0, seconds_to_microseconds),
-            can_play: np.can_play || !np.is_playing,
-            can_pause: np.can_pause || np.is_playing,
+            updated_at: Some(now),
+            can_play: plan.can_play,
+            can_pause: plan.can_pause,
             can_next: np.can_next,
             can_previous: np.can_previous,
         }
@@ -238,19 +390,29 @@ impl MprisState {
         }
     }
 
+    /// Whether the Metadata-relevant fields match `other` (position/timing and
+    /// capability fields are excluded).
+    fn same_metadata(&self, other: &Self) -> bool {
+        self.track == other.track
+            && self.artist == other.artist
+            && self.album == other.album
+            && self.art_url == other.art_url
+            && self.length_us == other.length_us
+    }
+
     fn metadata(&self) -> HashMap<String, OwnedValue> {
         let mut metadata = HashMap::new();
 
-        // No current track => empty Metadata, per the MPRIS spec. A trackid is
-        // only valid when a track is present, so we must not synthesize one
-        // here (and the `/.../TrackList/NoTrack` sentinel belongs to the
-        // TrackList interface, not Player.Metadata).
+        // No current track => empty Metadata, per the MPRIS spec (a trackid is
+        // only valid when a track is present, so none may be synthesized).
         if self.track.is_none() {
             return metadata;
         }
 
-        // mpris:trackid must be stable per track and must not be "/". A content
-        // hash differs across tracks but not across updates of one.
+        // mpris:trackid must be stable per track and must not be "/". A
+        // content hash differs across tracks but not across updates of one;
+        // the upstream payload carries no queue-item identity, so an
+        // identical track replayed back-to-back keeps the same id.
         let track_id = ObjectPath::try_from(track_id_path(
             self.track.as_deref(),
             self.artist.as_deref(),
@@ -271,8 +433,8 @@ impl MprisState {
         if let Some(album) = &self.album {
             metadata.insert("xesam:album".to_string(), owned_value(album.clone()));
         }
-        if let Some(art_url) = &self.art_url {
-            metadata.insert("mpris:artUrl".to_string(), owned_value(art_url.clone()));
+        if let Some(art_url) = self.art_url.as_deref().and_then(sanitize_art_url) {
+            metadata.insert("mpris:artUrl".to_string(), owned_value(art_url));
         }
         if let Some(length_us) = self.length_us {
             metadata.insert("mpris:length".to_string(), owned_value(length_us));
@@ -281,8 +443,22 @@ impl MprisState {
         metadata
     }
 
-    fn position_us(&self) -> i64 {
-        self.position_us
+    /// Current playback position, extrapolated from the last reported value
+    /// when playing (clients do the same, per the spec: position progresses
+    /// with Rate between Seeked signals) and clamped to `[0, mpris:length]`.
+    fn position_at(&self, now: Instant) -> i64 {
+        let mut position = self.position_us;
+        if self.playback_status == PlaybackState::Playing {
+            if let Some(updated_at) = self.updated_at {
+                let elapsed = now.saturating_duration_since(updated_at);
+                position =
+                    position.saturating_add(elapsed.as_micros().min(i64::MAX as u128) as i64);
+            }
+        }
+        if let Some(length_us) = self.length_us {
+            position = position.min(length_us);
+        }
+        position.max(0)
     }
 }
 
@@ -295,6 +471,16 @@ fn track_id_path(track: Option<&str>, artist: Option<&str>, album: Option<&str>)
         "/org/music_assistant/desktop/track_{:016x}",
         hasher.finish()
     )
+}
+
+/// Validate an artwork URL for `mpris:artUrl`: `data:` URL support varies
+/// across desktop environments and relative/bare paths are not valid URLs at
+/// all, so only pass through the schemes that work everywhere.
+fn sanitize_art_url(url: &str) -> Option<String> {
+    let scheme_ok = ["http:", "https:", "file:"]
+        .iter()
+        .any(|scheme| url.len() > scheme.len() && url[..scheme.len()].eq_ignore_ascii_case(scheme));
+    scheme_ok.then(|| url.to_string())
 }
 
 fn seconds_to_microseconds(secs: f64) -> i64 {
@@ -321,10 +507,25 @@ fn percent_to_mpris_volume(volume: u8) -> f64 {
     f64::from(volume.min(100)) / 100.0
 }
 
-/// Current player volume as an MPRIS `Volume` value. Falls back to full
-/// volume when the sendspin client is not connected or hasn't reported yet.
+/// Current player volume as an MPRIS `Volume` value: the last value observed
+/// via the sendspin listener or requested via `SetVolume`, seeded once from
+/// the live sendspin snapshot. See [`LAST_VOLUME`] for why this getter never
+/// overwrites an already-seeded value. Full volume when nothing is known yet.
 fn current_mpris_volume() -> f64 {
-    sendspin::get_volume_percent().map_or(1.0, percent_to_mpris_volume)
+    let mut last = LAST_VOLUME.lock();
+    if let Some(volume) = *last {
+        return volume;
+    }
+    match sendspin::get_volume_percent() {
+        Ok(percent) => {
+            let volume = percent_to_mpris_volume(percent);
+            *last = Some(volume);
+            volume
+        }
+        // Not seeded and no live value: report full volume but do NOT seed,
+        // so the first real report can still take over.
+        Err(_) => 1.0,
+    }
 }
 
 fn owned_value<'a, T>(value: T) -> OwnedValue
@@ -345,7 +546,9 @@ struct MediaPlayer2Root;
 #[allow(clippy::unused_self, unused_variables)]
 #[interface(name = "org.mpris.MediaPlayer2")]
 impl MediaPlayer2Root {
-    fn raise(&self) {}
+    fn raise(&self) {
+        crate::raise_main_window();
+    }
 
     fn quit(&self) {}
 
@@ -360,7 +563,13 @@ impl MediaPlayer2Root {
     }
 
     #[zbus(property)]
-    fn set_fullscreen(&self, fullscreen: bool) {}
+    fn set_fullscreen(&self, fullscreen: bool) -> fdo::Result<()> {
+        // CanSetFullscreen is false; per the spec clients may not call this,
+        // and silently swallowing the write would leave them out of sync.
+        Err(fdo::Error::NotSupported(
+            "Fullscreen cannot be set".to_string(),
+        ))
+    }
 
     #[zbus(property)]
     fn can_set_fullscreen(&self) -> bool {
@@ -369,7 +578,7 @@ impl MediaPlayer2Root {
 
     #[zbus(property)]
     fn can_raise(&self) -> bool {
-        false
+        true
     }
 
     #[zbus(property)]
@@ -432,11 +641,19 @@ impl MediaPlayer2Player {
         self.command("play");
     }
 
+    // CanSeek is false: per the spec, Seek and SetPosition then "have no
+    // effect" — a silent no-op is the sanctioned behavior, unlike the
+    // writable-property stubs below which must error instead.
     fn seek(&self, offset: i64) {}
 
     fn set_position(&self, track_id: ObjectPath<'_>, position: i64) {}
 
     fn open_uri(&self, uri: &str) {}
+
+    /// Position changed in a way that must not be extrapolated from Rate
+    /// (i.e. a seek). Emitted by the service loop, never spontaneously here.
+    #[zbus(signal)]
+    async fn seeked(emitter: &SignalEmitter<'_>, position: i64) -> zbus::Result<()>;
 
     #[zbus(property)]
     fn playback_status(&self) -> String {
@@ -449,7 +666,13 @@ impl MediaPlayer2Player {
     }
 
     #[zbus(property)]
-    fn set_loop_status(&self, loop_status: &str) {}
+    fn set_loop_status(&self, loop_status: &str) -> fdo::Result<()> {
+        // MPRIS has no CanLoop guard; erroring (instead of silently ignoring
+        // the write) is the only way to tell clients the toggle didn't take.
+        Err(fdo::Error::NotSupported(
+            "Loop status cannot be changed".to_string(),
+        ))
+    }
 
     #[zbus(property)]
     fn rate(&self) -> f64 {
@@ -457,7 +680,14 @@ impl MediaPlayer2Player {
     }
 
     #[zbus(property)]
-    fn set_rate(&self, rate: f64) {}
+    fn set_rate(&self, rate: f64) {
+        // Spec: a client setting Rate to 0.0 must be treated as Pause; other
+        // values outside [MinimumRate, MaximumRate] (both 1.0 here) should
+        // simply not take effect.
+        if rate == 0.0 {
+            self.command("pause");
+        }
+    }
 
     #[zbus(property)]
     fn shuffle(&self) -> bool {
@@ -465,7 +695,11 @@ impl MediaPlayer2Player {
     }
 
     #[zbus(property)]
-    fn set_shuffle(&self, shuffle: bool) {}
+    fn set_shuffle(&self, shuffle: bool) -> fdo::Result<()> {
+        Err(fdo::Error::NotSupported(
+            "Shuffle cannot be changed".to_string(),
+        ))
+    }
 
     #[zbus(property)]
     fn metadata(&self) -> HashMap<String, OwnedValue> {
@@ -479,16 +713,23 @@ impl MediaPlayer2Player {
 
     #[zbus(property)]
     fn set_volume(&self, volume: f64) {
-        // Fire-and-forget: the applied value flows back through the sendspin
-        // volume listener, which re-emits the `Volume` property.
+        // Optimistically record the requested value so the automatic
+        // PropertiesChanged from this set carries it (instead of a stale
+        // snapshot the applet would briefly snap back to); the applied value
+        // then flows back through the sendspin volume listener, which
+        // re-emits `Volume` with the authoritative number.
+        *LAST_VOLUME.lock() = Some(sanitize_mpris_volume(volume));
         if let Err(e) = sendspin::set_volume_percent(mpris_volume_to_percent(volume)) {
             log::warn!("[MediaControls] Failed to set Linux MPRIS volume: {e}");
         }
     }
 
-    #[zbus(property)]
+    // The MPRIS spec annotates Position with EmitsChangedSignal=false:
+    // clients track it via Rate extrapolation and the Seeked signal, and we
+    // never emit it in PropertiesChanged — advertise that in introspection.
+    #[zbus(property(emits_changed_signal = "false"))]
     fn position(&self) -> i64 {
-        self.state.snapshot().position_us()
+        self.state.snapshot().position_at(Instant::now())
     }
 
     #[zbus(property)]
@@ -541,6 +782,11 @@ impl MediaPlayer2Player {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
+    fn state_from(np: &NowPlaying) -> MprisState {
+        MprisState::from_now_playing(np, Instant::now())
+    }
 
     #[test]
     fn canonical_linux_identity_matches_packaging() {
@@ -557,11 +803,14 @@ mod tests {
 
     #[test]
     fn stopped_without_track_has_stopped_status() {
-        let state = MprisState::from_now_playing(&NowPlaying::default());
+        let state = state_from(&NowPlaying::default());
         assert_eq!(state.playback_status(), "Stopped");
-        assert_eq!(state.position_us(), 0);
+        assert_eq!(state.position_at(Instant::now()), 0);
         // With no current track, MPRIS Metadata must be empty (no trackid).
         assert!(state.metadata().is_empty());
+        // And no current track means nothing can be played or paused.
+        assert!(!state.can_play);
+        assert!(!state.can_pause);
     }
 
     #[test]
@@ -579,11 +828,12 @@ mod tests {
             ..Default::default()
         };
 
-        let state = MprisState::from_now_playing(&np);
+        let now = Instant::now();
+        let state = MprisState::from_now_playing(&np, now);
         let metadata = state.metadata();
 
         assert_eq!(state.playback_status(), "Playing");
-        assert_eq!(state.position_us(), 5_500_000);
+        assert_eq!(state.position_at(now), 5_500_000);
         assert_eq!(state.length_us, Some(123_400_000));
         assert!(metadata.contains_key("mpris:trackid"));
         assert!(metadata.contains_key("xesam:title"));
@@ -596,18 +846,396 @@ mod tests {
     }
 
     #[test]
+    fn can_play_and_can_pause_are_state_independent() {
+        // Spec: CanPlay/CanPause are intrinsic to the current track and must
+        // not flip with is_playing, even though the upstream flags do.
+        let playing = state_from(&NowPlaying {
+            is_playing: true,
+            track: Some("Song".to_string()),
+            can_pause: true,
+            ..Default::default()
+        });
+        assert!(playing.can_play, "CanPlay must stay true while playing");
+        assert!(playing.can_pause);
+
+        let paused = state_from(&NowPlaying {
+            is_playing: false,
+            track: Some("Song".to_string()),
+            can_play: true,
+            ..Default::default()
+        });
+        assert!(paused.can_play);
+        assert!(paused.can_pause, "CanPause must stay true while paused");
+
+        // Playing with both upstream flags unset: is_playing alone must keep
+        // the pair true.
+        let playing_no_flags = state_from(&NowPlaying {
+            is_playing: true,
+            track: Some("Song".to_string()),
+            ..Default::default()
+        });
+        assert!(playing_no_flags.can_play);
+        assert!(playing_no_flags.can_pause);
+    }
+
+    /// GNOME Shell removes the media card the moment `CanPlay` goes false and
+    /// resets its position tracking when `Metadata` changes, so a pause<->play
+    /// transition must change neither the capability pair nor the `Metadata`.
+    #[test]
+    fn paused_to_playing_preserves_track_identity_and_metadata() {
+        let base = NowPlaying {
+            track: Some("Song".to_string()),
+            artist: Some("Artist".to_string()),
+            album: Some("Album".to_string()),
+            image_url: Some("https://example.test/cover.jpg".to_string()),
+            duration: Some(123.4),
+            elapsed: Some(5.5),
+            can_next: true,
+            can_previous: true,
+            ..Default::default()
+        };
+        let paused = state_from(&NowPlaying {
+            is_playing: false,
+            can_play: true,
+            ..base.clone()
+        });
+        let playing = state_from(&NowPlaying {
+            is_playing: true,
+            can_pause: true,
+            ..base
+        });
+
+        assert_eq!(paused.playback_status(), "Paused");
+        assert_eq!(playing.playback_status(), "Playing");
+        assert!(playing.can_play);
+        assert!(paused.can_pause);
+        assert_eq!(paused.metadata(), playing.metadata());
+        assert!(playing.metadata().contains_key("mpris:trackid"));
+    }
+
+    #[test]
+    fn position_extrapolates_while_playing_and_clamps_to_length() {
+        let now = Instant::now();
+        let mut state = MprisState::from_now_playing(
+            &NowPlaying {
+                is_playing: true,
+                track: Some("Song".to_string()),
+                duration: Some(100.0),
+                elapsed: Some(98.0),
+                ..Default::default()
+            },
+            now,
+        );
+
+        // 1 second into playback: extrapolated forward.
+        let later = now + Duration::from_secs(1);
+        assert_eq!(state.position_at(later), 99_000_000);
+
+        // 5 seconds in: clamped to mpris:length.
+        let much_later = now + Duration::from_secs(5);
+        assert_eq!(state.position_at(much_later), 100_000_000);
+
+        // Paused: frozen at the reported value.
+        state.playback_status = PlaybackState::Paused;
+        assert_eq!(state.position_at(much_later), 98_000_000);
+    }
+
+    #[test]
+    fn seek_jump_detected_for_same_track_deviation() {
+        let now = Instant::now();
+        let np = NowPlaying {
+            is_playing: true,
+            track: Some("Song".to_string()),
+            duration: Some(300.0),
+            elapsed: Some(10.0),
+            ..Default::default()
+        };
+        let previous = MprisState::from_now_playing(&np, now);
+
+        // Progress tick consistent with extrapolation: no Seeked.
+        let ticked = MprisState::from_now_playing(
+            &NowPlaying {
+                elapsed: Some(10.2),
+                ..np.clone()
+            },
+            now,
+        );
+        assert_eq!(seek_jump(&previous, &ticked, now), None);
+
+        // Jump well beyond the threshold: Seeked at the new position.
+        let sought = MprisState::from_now_playing(
+            &NowPlaying {
+                elapsed: Some(120.0),
+                ..np.clone()
+            },
+            now,
+        );
+        assert_eq!(seek_jump(&previous, &sought, now), Some(120_000_000));
+    }
+
+    #[test]
+    fn seek_jump_on_track_change_only_when_starting_off_zero() {
+        let now = Instant::now();
+        let previous = MprisState::from_now_playing(
+            &NowPlaying {
+                is_playing: true,
+                track: Some("Song".to_string()),
+                elapsed: Some(100.0),
+                ..Default::default()
+            },
+            now,
+        );
+
+        // New track starting at 0: clients reset on the Metadata change.
+        let next_track = MprisState::from_now_playing(
+            &NowPlaying {
+                is_playing: true,
+                track: Some("Other".to_string()),
+                elapsed: Some(0.0),
+                ..Default::default()
+            },
+            now,
+        );
+        assert_eq!(seek_jump(&previous, &next_track, now), None);
+
+        // New track resuming mid-way: must be announced.
+        let resumed = MprisState::from_now_playing(
+            &NowPlaying {
+                is_playing: true,
+                track: Some("Other".to_string()),
+                elapsed: Some(42.0),
+                ..Default::default()
+            },
+            now,
+        );
+        assert_eq!(seek_jump(&previous, &resumed, now), Some(42_000_000));
+
+        // No track at all: nothing to announce.
+        let cleared = MprisState::default();
+        assert_eq!(seek_jump(&previous, &cleared, now), None);
+    }
+
+    #[test]
+    fn seek_jump_uses_extrapolation_for_stale_previous_state() {
+        // The previous state was captured 10s ago while playing; clients have
+        // extrapolated 10s forward on their own since then.
+        let start = Instant::now();
+        let np = NowPlaying {
+            is_playing: true,
+            track: Some("Song".to_string()),
+            duration: Some(300.0),
+            elapsed: Some(10.0),
+            ..Default::default()
+        };
+        let previous = MprisState::from_now_playing(&np, start);
+        let now = start + Duration::from_secs(10);
+
+        // Fresh report consistent with extrapolation (10 + 10): no Seeked.
+        let ticked = MprisState::from_now_playing(
+            &NowPlaying {
+                elapsed: Some(20.0),
+                ..np.clone()
+            },
+            now,
+        );
+        assert_eq!(seek_jump(&previous, &ticked, now), None);
+
+        // Fresh report far off the extrapolation: Seeked.
+        let sought = MprisState::from_now_playing(
+            &NowPlaying {
+                elapsed: Some(40.0),
+                ..np.clone()
+            },
+            now,
+        );
+        assert_eq!(seek_jump(&previous, &sought, now), Some(40_000_000));
+    }
+
+    #[test]
+    fn pause_transition_does_not_emit_spurious_seeked() {
+        // Last Playing update 3s ago at 10s; the user pauses and the frontend
+        // reports the position as of the pause (~10-13s), which lags the 13s
+        // extrapolation. That is not a seek.
+        let start = Instant::now();
+        let playing = NowPlaying {
+            is_playing: true,
+            track: Some("Song".to_string()),
+            duration: Some(300.0),
+            elapsed: Some(10.0),
+            ..Default::default()
+        };
+        let previous = MprisState::from_now_playing(&playing, start);
+        let now = start + Duration::from_secs(3);
+
+        let paused_at_report = MprisState::from_now_playing(
+            &NowPlaying {
+                is_playing: false,
+                elapsed: Some(10.2),
+                ..playing.clone()
+            },
+            now,
+        );
+        assert_eq!(seek_jump(&previous, &paused_at_report, now), None);
+
+        // A genuine seek-while-pausing (far from both the frozen and the
+        // extrapolated view) must still be announced.
+        let paused_after_seek = MprisState::from_now_playing(
+            &NowPlaying {
+                is_playing: false,
+                elapsed: Some(120.0),
+                ..playing.clone()
+            },
+            now,
+        );
+        assert_eq!(
+            seek_jump(&previous, &paused_after_seek, now),
+            Some(120_000_000)
+        );
+
+        // Resume whose first report runs slightly ahead of the frozen pause
+        // position (normal upstream jitter): tolerated, not a seek.
+        let resumed_with_jitter = MprisState::from_now_playing(
+            &NowPlaying {
+                is_playing: true,
+                elapsed: Some(11.2),
+                ..playing.clone()
+            },
+            now,
+        );
+        let frozen = MprisState::from_now_playing(
+            &NowPlaying {
+                is_playing: false,
+                elapsed: Some(10.0),
+                ..playing.clone()
+            },
+            now,
+        );
+        assert_eq!(seek_jump(&frozen, &resumed_with_jitter, now), None);
+    }
+
+    #[test]
+    fn zero_duration_is_no_length_not_zero_length() {
+        let now = Instant::now();
+        let state = MprisState::from_now_playing(
+            &NowPlaying {
+                is_playing: true,
+                track: Some("Radio".to_string()),
+                duration: Some(0.0),
+                elapsed: Some(45.0),
+                ..Default::default()
+            },
+            now,
+        );
+        assert_eq!(state.length_us, None, "0 duration is live/unknown");
+        // Position must not be clamped to a bogus zero-length track.
+        assert_eq!(state.position_at(now), 45_000_000);
+        assert!(!state.metadata().contains_key("mpris:length"));
+    }
+
+    #[test]
+    fn changed_properties_diffs_against_last_emission() {
+        let now = Instant::now();
+        let np = NowPlaying {
+            is_playing: true,
+            track: Some("Song".to_string()),
+            duration: Some(300.0),
+            elapsed: Some(10.0),
+            can_next: true,
+            ..Default::default()
+        };
+        let snapshot = MprisState::from_now_playing(&np, now);
+
+        // First emission: everything goes out.
+        let first = changed_properties(None, &snapshot, 0.5);
+        for key in [
+            "PlaybackStatus",
+            "Metadata",
+            "CanPlay",
+            "CanPause",
+            "CanGoNext",
+            "CanGoPrevious",
+            "Volume",
+        ] {
+            assert!(first.contains_key(key), "first emission must include {key}");
+        }
+
+        let last = EmittedProperties {
+            state: snapshot.clone(),
+            volume: 0.5,
+        };
+
+        // Progress tick: same metadata/status/caps/volume => nothing at all
+        // (Position is deliberately never part of PropertiesChanged).
+        let tick = MprisState::from_now_playing(
+            &NowPlaying {
+                elapsed: Some(11.0),
+                ..np.clone()
+            },
+            now,
+        );
+        assert!(changed_properties(Some(&last), &tick, 0.5).is_empty());
+
+        // Pause: only PlaybackStatus (caps are state-independent). The
+        // frontend flips its capability flags with state, so a real pause
+        // arrives with can_play set instead of is_playing.
+        let paused = MprisState::from_now_playing(
+            &NowPlaying {
+                is_playing: false,
+                can_play: true,
+                ..np.clone()
+            },
+            now,
+        );
+        let diff = changed_properties(Some(&last), &paused, 0.5);
+        assert!(diff.contains_key("PlaybackStatus"));
+        assert!(!diff.contains_key("Metadata"));
+        assert!(!diff.contains_key("CanPlay"));
+
+        // Volume delta is bit-exact.
+        let diff = changed_properties(Some(&last), &snapshot, 0.51);
+        assert_eq!(diff.len(), 1);
+        assert!(diff.contains_key("Volume"));
+    }
+
+    #[test]
+    fn art_url_schemes_are_sanitized() {
+        assert_eq!(
+            sanitize_art_url("https://host/cover.jpg").as_deref(),
+            Some("https://host/cover.jpg")
+        );
+        assert_eq!(
+            sanitize_art_url("HTTP://host/cover.jpg").as_deref(),
+            Some("HTTP://host/cover.jpg")
+        );
+        assert_eq!(
+            sanitize_art_url("file:///tmp/cover.jpg").as_deref(),
+            Some("file:///tmp/cover.jpg")
+        );
+        assert_eq!(sanitize_art_url("data:image/png;base64,AAAA"), None);
+        assert_eq!(sanitize_art_url("/relative/path.jpg"), None);
+        assert_eq!(sanitize_art_url(""), None);
+
+        let state = state_from(&NowPlaying {
+            track: Some("Song".to_string()),
+            image_url: Some("data:image/png;base64,AAAA".to_string()),
+            ..Default::default()
+        });
+        assert!(!state.metadata().contains_key("mpris:artUrl"));
+    }
+
+    #[test]
     fn trackid_is_stable_per_track_but_differs_across_tracks() {
-        let a = MprisState::from_now_playing(&NowPlaying {
+        let a = state_from(&NowPlaying {
             track: Some("Song".to_string()),
             artist: Some("Artist".to_string()),
             ..Default::default()
         });
-        let a_dup = MprisState::from_now_playing(&NowPlaying {
+        let a_dup = state_from(&NowPlaying {
             track: Some("Song".to_string()),
             artist: Some("Artist".to_string()),
             ..Default::default()
         });
-        let b = MprisState::from_now_playing(&NowPlaying {
+        let b = state_from(&NowPlaying {
             track: Some("Other".to_string()),
             artist: Some("Artist".to_string()),
             ..Default::default()

--- a/src-tauri/src/media_controls/macos.rs
+++ b/src-tauri/src/media_controls/macos.rs
@@ -6,7 +6,9 @@
 //! the [`MainThreadDispatch`](super::MainThreadDispatch) given to [`init`];
 //! `AppKit` delivers remote-command handlers there too. Nothing objc2 is kept in
 //! a static (those types are `!Send`) — only plain data is, and the framework
-//! singletons are re-fetched inside each main-thread closure.
+//! singletons are re-fetched inside each main-thread closure. (The one
+//! main-thread-only objc2 cache, the decoded artwork, lives in a
+//! `thread_local` instead.)
 #![allow(unsafe_code)] // objc2 framework methods are all `unsafe`; lift the workspace deny.
 
 use super::{MainThreadDispatch, MediaControlCallback, NowPlayingPlan, PlaybackState};
@@ -17,20 +19,26 @@ use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2::AnyThread;
 use objc2_app_kit::NSImage;
 use objc2_core_foundation::CGSize;
-use objc2_foundation::{NSCopying, NSData, NSMutableDictionary, NSNumber, NSString};
+use objc2_foundation::{
+    NSCopying, NSData, NSDataBase64DecodingOptions, NSMutableDictionary, NSNumber, NSString, NSURL,
+};
 use objc2_media_player::{
     MPMediaItemArtwork, MPMediaItemPropertyAlbumTitle, MPMediaItemPropertyArtist,
     MPMediaItemPropertyArtwork, MPMediaItemPropertyPlaybackDuration, MPMediaItemPropertyTitle,
-    MPNowPlayingInfoCenter, MPNowPlayingInfoPropertyElapsedPlaybackTime,
-    MPNowPlayingInfoPropertyPlaybackRate, MPRemoteCommand, MPRemoteCommandCenter,
-    MPRemoteCommandEvent, MPRemoteCommandHandlerStatus,
+    MPNowPlayingInfoCenter, MPNowPlayingInfoMediaType, MPNowPlayingInfoPropertyDefaultPlaybackRate,
+    MPNowPlayingInfoPropertyElapsedPlaybackTime, MPNowPlayingInfoPropertyIsLiveStream,
+    MPNowPlayingInfoPropertyMediaType, MPNowPlayingInfoPropertyPlaybackRate,
+    MPNowPlayingPlaybackState, MPRemoteCommand, MPRemoteCommandCenter, MPRemoteCommandEvent,
+    MPRemoteCommandHandlerStatus,
 };
 use parking_lot::Mutex;
+use std::cell::RefCell;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+/// Fallback artwork bounds when the decoded image reports a degenerate size.
 const ARTWORK_SIZE: f64 = 512.0;
 const COVER_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_COVER_BYTES: u64 = 8 * 1024 * 1024;
@@ -42,6 +50,27 @@ static COVER: Mutex<CoverCache> = Mutex::new(CoverCache::EMPTY);
 /// Invalidates any in-flight cover download when the track changes.
 static COVER_GEN: AtomicU64 = AtomicU64::new(0);
 static COMMANDS_REGISTERED: AtomicBool = AtomicBool::new(false);
+
+thread_local! {
+    /// Main-thread cache of the `MPMediaItemArtwork` for the current cover
+    /// bytes (keyed by the `Arc` pointer identity). Rebuilding the artwork
+    /// object on every progress tick would make the system re-request and
+    /// re-decode the image each time; caching also remembers a failed decode
+    /// so undecodable bytes are validated once and then omitted instead of
+    /// rendering a blank tile.
+    static ARTWORK_CACHE: RefCell<Option<CachedArtwork>> = const { RefCell::new(None) };
+}
+
+struct CachedArtwork {
+    /// The cover bytes this entry was built from. Held (not just their
+    /// pointer) so the allocation cannot be freed and reused while the entry
+    /// lives — comparing raw `Arc::as_ptr` keys without retaining would let a
+    /// later cover alias a stale entry (ABA), in particular hitting a cached
+    /// failed-decode `None` for perfectly decodable new bytes.
+    bytes: Arc<Vec<u8>>,
+    /// `None` records that the bytes failed to decode as an image.
+    artwork: Option<Retained<MPMediaItemArtwork>>,
+}
 
 /// Cover bytes (not an objc2 object) so the cache stays `Send`.
 struct CoverCache {
@@ -68,8 +97,12 @@ pub fn init(callback: MediaControlCallback, dispatch: MainThreadDispatch) {
 
 pub fn update(np: &NowPlaying) {
     let plan = super::plan(np);
+    // Publish the plan before kicking off the cover fetch: a near-instant
+    // fetch (data:/file: URL) can complete and dispatch a render before this
+    // function finishes, and that render must not observe the previous
+    // track's plan with the new track's artwork.
+    *LAST_PLAN.lock() = Some(plan.clone());
     refresh_cover_if_changed(&plan);
-    *LAST_PLAN.lock() = Some(plan);
     dispatch_render();
 }
 
@@ -81,7 +114,15 @@ pub fn clear() {
         return;
     };
     dispatch(Box::new(|| unsafe {
-        MPNowPlayingInfoCenter::defaultCenter().setNowPlayingInfo(None);
+        let center = MPNowPlayingInfoCenter::defaultCenter();
+        center.setNowPlayingInfo(None);
+        // `playbackState` is the macOS-specific app-level signal (Control
+        // Center visibility, media-key routing); it must be cleared too.
+        center.setPlaybackState(MPNowPlayingPlaybackState::Stopped);
+        // Enablement is per-item; with no item, nothing is actionable.
+        apply_command_enablement(&super::plan(&NowPlaying::default()));
+        // Drop the retained artwork object along with the cover it belonged to.
+        ARTWORK_CACHE.with(|cache| *cache.borrow_mut() = None);
     }));
 }
 
@@ -103,7 +144,7 @@ fn refresh_cover_if_changed(plan: &NowPlayingPlan) {
         return;
     };
 
-    std::thread::spawn(move || match download_image(&url) {
+    std::thread::spawn(move || match fetch_cover(&url) {
         Ok(bytes) => {
             if COVER_GEN.load(Ordering::SeqCst) != generation {
                 return; // Superseded by a newer track.
@@ -117,8 +158,83 @@ fn refresh_cover_if_changed(plan: &NowPlayingPlan) {
             }
             dispatch_render();
         }
-        Err(e) => log::warn!("[MediaControls] cover download failed for {url}: {e}"),
+        Err(e) => log::warn!("[MediaControls] cover fetch failed for {url}: {e}"),
     });
+}
+
+/// Fetch cover bytes for any of the URL forms the upstream may hand us.
+/// Apple natively supports `data:` URLs for artwork, and local `file:` URLs
+/// are cheaper than a loopback HTTP fetch; everything else goes over HTTP.
+fn fetch_cover(url: &str) -> Result<Vec<u8>, String> {
+    if let Some(rest) = url.strip_prefix("data:") {
+        decode_data_url(rest)
+    } else if url.starts_with("file:") {
+        read_file_url(url)
+    } else {
+        download_image(url).map_err(|e| e.to_string())
+    }
+}
+
+/// Decode the payload of a `data:` URL (the part after `data:`). Only the
+/// base64 form is supported; covers are binary image data in practice.
+fn decode_data_url(rest: &str) -> Result<Vec<u8>, String> {
+    let (media_type, payload) = rest
+        .split_once(',')
+        .ok_or_else(|| "malformed data: URL (no comma)".to_string())?;
+    if !media_type.ends_with(";base64") {
+        return Err("only base64-encoded data: URLs are supported".to_string());
+    }
+    // RFC 2397 allows URL-encoded payloads ("+" as "%2B" etc.); decode those
+    // first, then decode base64 STRICTLY — a lenient decoder that skips
+    // unknown characters would silently turn a still-percent-encoded payload
+    // into garbage bytes instead of an error.
+    let payload = percent_decode(payload);
+    // NSData's decoder avoids adding a base64 dependency; NSData/NSString are
+    // immutable and safe to use off the main thread.
+    let payload = NSString::from_str(&payload);
+    let data = NSData::initWithBase64EncodedString_options(
+        NSData::alloc(),
+        &payload,
+        NSDataBase64DecodingOptions::empty(),
+    )
+    .ok_or_else(|| "invalid base64 payload in data: URL".to_string())?;
+    Ok(data.to_vec())
+}
+
+/// Percent-decode a data:-URL payload. Valid `%XX` escapes are decoded;
+/// anything else passes through unchanged. Base64 payloads are ASCII, so
+/// decoded escapes are folded back into the string lossily.
+fn percent_decode(payload: &str) -> String {
+    fn hex_digit(byte: u8) -> Option<u8> {
+        (byte as char).to_digit(16).map(|d| d as u8)
+    }
+
+    let bytes = payload.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(hi), Some(lo)) = (hex_digit(bytes[i + 1]), hex_digit(bytes[i + 2])) {
+                out.push(hi * 16 + lo);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Read a `file:` URL, letting NSURL handle percent-decoding of the path.
+fn read_file_url(url: &str) -> Result<Vec<u8>, String> {
+    let parsed = NSURL::URLWithString(&NSString::from_str(url))
+        .ok_or_else(|| "invalid file: URL".to_string())?;
+    let path = parsed
+        .path()
+        .ok_or_else(|| "file: URL has no path".to_string())?
+        .to_string();
+    std::fs::read(&path).map_err(|e| e.to_string())
 }
 
 fn download_image(url: &str) -> Result<Vec<u8>, ureq::Error> {
@@ -147,12 +263,39 @@ unsafe fn render() {
         return;
     };
     let center = MPNowPlayingInfoCenter::defaultCenter();
+
+    // Remote-command availability must track the current item; commands left
+    // permanently enabled would offer next/previous for non-skippable queues.
+    apply_command_enablement(&plan);
+
     if plan.state == PlaybackState::Stopped {
         center.setNowPlayingInfo(None);
+        center.setPlaybackState(MPNowPlayingPlaybackState::Stopped);
         return;
     }
     let info = build_info_dict(&plan);
     center.setNowPlayingInfo(Some(&info));
+    // On macOS, `playbackState` (not the playback rate) is what drives
+    // Control Center / menu-bar Now Playing state and makes this app the
+    // current now-playing app for media keys and AirPods controls. Set it
+    // after the info dictionary so the state change observes fresh metadata.
+    center.setPlaybackState(match plan.state {
+        PlaybackState::Playing => MPNowPlayingPlaybackState::Playing,
+        PlaybackState::Paused => MPNowPlayingPlaybackState::Paused,
+        PlaybackState::Stopped => MPNowPlayingPlaybackState::Stopped,
+    });
+}
+
+unsafe fn apply_command_enablement(plan: &NowPlayingPlan) {
+    let center = MPRemoteCommandCenter::sharedCommandCenter();
+    center.playCommand().setEnabled(plan.can_play);
+    center.pauseCommand().setEnabled(plan.can_pause);
+    center
+        .togglePlayPauseCommand()
+        .setEnabled(plan.can_play || plan.can_pause);
+    center.nextTrackCommand().setEnabled(plan.can_next);
+    center.previousTrackCommand().setEnabled(plan.can_previous);
+    center.stopCommand().setEnabled(plan.title.is_some());
 }
 
 unsafe fn build_info_dict(
@@ -176,10 +319,24 @@ unsafe fn build_info_dict(
         set_number(&dict, MPNowPlayingInfoPropertyElapsedPlaybackTime, elapsed);
     }
     set_number(&dict, MPNowPlayingInfoPropertyPlaybackRate, plan.rate);
+    set_number(&dict, MPNowPlayingInfoPropertyDefaultPlaybackRate, 1.0);
+
+    // We are a music app; the default media type is "none", which the system
+    // treats as untyped media.
+    let media_type = NSNumber::numberWithUnsignedInteger(MPNowPlayingInfoMediaType::Audio.0);
+    dict.setObject_forKey(&media_type, copying_key(MPNowPlayingInfoPropertyMediaType));
+
+    // A live stream gets the live UI in Control Center instead of an
+    // indeterminate scrubber for an unknown-length item.
+    if plan.live {
+        let live = NSNumber::numberWithBool(true);
+        dict.setObject_forKey(&live, copying_key(MPNowPlayingInfoPropertyIsLiveStream));
+    }
 
     if let Some(bytes) = COVER.lock().bytes.clone() {
-        let artwork = make_artwork(bytes);
-        dict.setObject_forKey(&artwork, copying_key(MPMediaItemPropertyArtwork));
+        if let Some(artwork) = cached_artwork(bytes) {
+            dict.setObject_forKey(&artwork, copying_key(MPMediaItemPropertyArtwork));
+        }
     }
 
     dict
@@ -199,18 +356,61 @@ fn copying_key(key: &NSString) -> &ProtocolObject<dyn NSCopying> {
     ProtocolObject::from_ref(key)
 }
 
+/// Artwork for the given cover bytes, built (and the bytes validated) at most
+/// once per cover. Must be called on the main thread. Returns `None` when the
+/// bytes are not decodable as an image, so a broken cover is omitted instead
+/// of showing a blank artwork tile.
+unsafe fn cached_artwork(bytes: Arc<Vec<u8>>) -> Option<Retained<MPMediaItemArtwork>> {
+    ARTWORK_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(cached) = cache.as_ref() {
+            if Arc::ptr_eq(&cached.bytes, &bytes) {
+                return cached.artwork.clone();
+            }
+        }
+
+        // Probe-decode once to validate the bytes and learn the image's
+        // natural bounds; the advertised bounds must agree with what the
+        // request handler actually returns.
+        let data = NSData::with_bytes(&bytes);
+        let artwork = if let Some(image) = NSImage::initWithData(NSImage::alloc(), &data) {
+            Some(make_artwork(bytes.clone(), image.size()))
+        } else {
+            log::warn!("[MediaControls] cover bytes are not a decodable image; omitting artwork");
+            None
+        };
+
+        let result = artwork.clone();
+        *cache = Some(CachedArtwork { bytes, artwork });
+        result
+    })
+}
+
 /// `AppKit` may invoke the request handler on any thread, so it touches only the
 /// thread-safe `NSData`/`NSImage` constructors and returns the image autoreleased
 /// (`+0`) via [`Retained::autorelease_return`], as the handler's contract expects.
-unsafe fn make_artwork(bytes: Arc<Vec<u8>>) -> Retained<MPMediaItemArtwork> {
-    let bounds = CGSize {
-        width: ARTWORK_SIZE,
-        height: ARTWORK_SIZE,
+unsafe fn make_artwork(bytes: Arc<Vec<u8>>, natural_size: CGSize) -> Retained<MPMediaItemArtwork> {
+    let bounds = if natural_size.width > 0.0 && natural_size.height > 0.0 {
+        natural_size
+    } else {
+        CGSize {
+            width: ARTWORK_SIZE,
+            height: ARTWORK_SIZE,
+        }
     };
-    let handler = RcBlock::new(move |_size: CGSize| -> NonNull<NSImage> {
+    let handler = RcBlock::new(move |size: CGSize| -> NonNull<NSImage> {
         let data = NSData::with_bytes(&bytes);
         let image = match NSImage::initWithData(NSImage::alloc(), &data) {
-            Some(image) => image,
+            Some(image) => {
+                // The handler contract is to return an image at the requested
+                // size; NSImage scales at draw time via its `size` property.
+                if size.width > 0.0 && size.height > 0.0 {
+                    image.setSize(size);
+                }
+                image
+            }
+            // Decode raced a cover change; an empty image keeps the contract
+            // (the bytes were already validated once in `cached_artwork`).
             None => NSImage::new(),
         };
         NonNull::new(Retained::autorelease_return(image))
@@ -233,13 +433,61 @@ unsafe fn register_commands() {
     add_handler(&center.stopCommand(), "stop");
 }
 
+/// Registers the handler and starts the command disabled; enablement is
+/// driven per-update by [`apply_command_enablement`]. The target returned by
+/// `addTargetWithHandler` is intentionally dropped: the registration lives
+/// for the whole app lifetime and is never detached (`removeTarget` would
+/// need the token, which we don't keep).
 unsafe fn add_handler(command: &MPRemoteCommand, action: &'static str) {
-    command.setEnabled(true);
+    command.setEnabled(false);
     let handler = RcBlock::new(move |_event: NonNull<MPRemoteCommandEvent>| {
+        // A command can still arrive with nothing actionable (e.g. queued
+        // events right after the last track was cleared); report that instead
+        // of claiming success.
+        let actionable = LAST_PLAN.lock().as_ref().is_some_and(|p| p.title.is_some());
+        if !actionable {
+            return MPRemoteCommandHandlerStatus::NoActionableNowPlayingItem;
+        }
         if let Some(callback) = CALLBACK.lock().clone() {
             callback(action);
         }
         MPRemoteCommandHandlerStatus::Success
     });
     let _target = command.addTargetWithHandler(&handler);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percent_decode_handles_escapes_and_passthrough() {
+        assert_eq!(percent_decode("AA%2B%2fBB"), "AA+/BB");
+        assert_eq!(percent_decode("plain=="), "plain==");
+        // Invalid/truncated escapes pass through untouched.
+        assert_eq!(percent_decode("50%"), "50%");
+        assert_eq!(percent_decode("%zz"), "%zz");
+        // Non-ASCII input must not panic.
+        assert_eq!(percent_decode("é%41"), "éA");
+    }
+
+    #[test]
+    fn decode_data_url_accepts_base64_and_rejects_other_forms() {
+        // "TUE=" is the base64 encoding of the bytes "MA".
+        assert_eq!(
+            decode_data_url("image/png;base64,TUE=").unwrap(),
+            b"MA".to_vec()
+        );
+        // Percent-encoded payload ("+" as %2B) decodes correctly: "+w==" => [0xFB].
+        assert_eq!(
+            decode_data_url("image/png;base64,%2Bw==").unwrap(),
+            vec![0xFB]
+        );
+        // Non-base64 form and malformed URLs are rejected, not corrupted.
+        assert!(decode_data_url("image/png,rawdata").is_err());
+        assert!(decode_data_url("no-comma-here").is_err());
+        // Strict decoding: garbage payload errors instead of silently
+        // decoding a subset of the characters.
+        assert!(decode_data_url("image/png;base64,@@@@").is_err());
+    }
 }

--- a/src-tauri/src/media_controls/mod.rs
+++ b/src-tauri/src/media_controls/mod.rs
@@ -55,6 +55,18 @@ pub fn update(np: &NowPlaying) {
     windows::update(np);
 }
 
+/// Re-bind the OS media controls to a new native window handle.
+///
+/// Only meaningful on Windows, where SMTC is attached to an HWND whose
+/// lifetime we don't control: logout/server-switch destroys the window the
+/// controls were bound to and creates a replacement, which would otherwise
+/// silently kill media keys and the SMTC flyout for the rest of the process.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code, unused_variables))]
+pub fn rebind(hwnd: Option<*mut std::ffi::c_void>) {
+    #[cfg(target_os = "windows")]
+    windows::rebind(hwnd);
+}
+
 #[allow(dead_code)]
 pub fn clear() {
     #[cfg(target_os = "linux")]
@@ -98,6 +110,17 @@ pub(crate) struct NowPlayingPlan {
     pub state: PlaybackState,
     pub rate: f64,
     pub image_url: Option<String>,
+    /// Whether the current item supports play, independent of playback state.
+    pub can_play: bool,
+    /// Whether the current item supports pause, independent of playback state.
+    pub can_pause: bool,
+    /// Whether skipping to the next queue item is available.
+    pub can_next: bool,
+    /// Whether skipping to the previous queue item is available.
+    pub can_previous: bool,
+    /// Whether the current item is a live/unknown-length stream (a track
+    /// present but no usable duration).
+    pub live: bool,
 }
 
 pub(crate) fn plan(np: &NowPlaying) -> NowPlayingPlan {
@@ -112,15 +135,35 @@ pub(crate) fn plan(np: &NowPlaying) -> NowPlayingPlan {
         PlaybackState::Playing => PLAYBACK_RATE_PLAYING,
         PlaybackState::Paused | PlaybackState::Stopped => PLAYBACK_RATE_STOPPED,
     };
+
+    // OS media surfaces treat play/pause availability as intrinsic to the
+    // current item (the MPRIS spec forbids deriving it from playback state),
+    // but the upstream flags flip with the transport (can_play only while
+    // paused, can_pause only while playing). Fold them back into one
+    // state-independent capability.
+    let has_track = np.track.is_some();
+    let controllable = has_track && (np.can_play || np.can_pause || np.is_playing);
+
+    // A non-positive or non-finite duration means "no known length" (live or
+    // unknown stream), not a zero-length track.
+    let duration_secs = np.duration.filter(|d| d.is_finite() && *d > 0.0);
+
     NowPlayingPlan {
         title: np.track.clone(),
         artist: np.artist.clone(),
         album: np.album.clone(),
-        duration_secs: np.duration,
+        duration_secs,
         elapsed_secs: np.elapsed,
         state,
         rate,
         image_url: np.image_url.clone(),
+        can_play: controllable,
+        can_pause: controllable,
+        // Queue navigation only applies while an item exists; mask stray
+        // upstream flags so no surface offers next/previous on an empty state.
+        can_next: has_track && np.can_next,
+        can_previous: has_track && np.can_previous,
+        live: has_track && duration_secs.is_none(),
     }
 }
 
@@ -168,6 +211,34 @@ mod tests {
     }
 
     #[test]
+    fn can_play_pause_are_state_independent() {
+        // Playing with only can_pause set upstream: play must stay available.
+        let mut playing = np(true, Some("Song"));
+        playing.can_pause = true;
+        let p = plan(&playing);
+        assert!(p.can_play);
+        assert!(p.can_pause);
+
+        // Paused with only can_play set upstream: pause must stay available.
+        let mut paused = np(false, Some("Song"));
+        paused.can_play = true;
+        let p = plan(&paused);
+        assert!(p.can_play);
+        assert!(p.can_pause);
+
+        // No track: neither action applies, even with stray upstream flags.
+        let mut empty = np(false, None);
+        empty.can_play = true;
+        empty.can_next = true;
+        empty.can_previous = true;
+        let p = plan(&empty);
+        assert!(!p.can_play);
+        assert!(!p.can_pause);
+        assert!(!p.can_next, "queue flags are masked without a track");
+        assert!(!p.can_previous);
+    }
+
+    #[test]
     fn maps_metadata_and_timing_fields() {
         let mut n = np(true, Some("Song"));
         n.artist = Some("Artist".to_owned());
@@ -175,6 +246,7 @@ mod tests {
         n.duration = Some(200.0);
         n.elapsed = Some(5.0);
         n.image_url = Some("http://host/cover.jpg".to_owned());
+        n.can_next = true;
 
         let p = plan(&n);
         assert_eq!(p.artist.as_deref(), Some("Artist"));
@@ -182,5 +254,32 @@ mod tests {
         assert_eq!(p.duration_secs, Some(200.0));
         assert_eq!(p.elapsed_secs, Some(5.0));
         assert_eq!(p.image_url.as_deref(), Some("http://host/cover.jpg"));
+        assert!(p.can_next);
+        assert!(!p.can_previous);
+        assert!(!p.live, "finite duration is not a live stream");
+    }
+
+    #[test]
+    fn live_stream_is_track_without_duration() {
+        let p = plan(&np(true, Some("Radio")));
+        assert!(p.live);
+
+        // No track at all is Stopped, not live.
+        let p = plan(&np(false, None));
+        assert!(!p.live);
+    }
+
+    #[test]
+    fn degenerate_durations_normalize_to_live() {
+        for degenerate in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let mut n = np(true, Some("Radio"));
+            n.duration = Some(degenerate);
+            let p = plan(&n);
+            assert_eq!(
+                p.duration_secs, None,
+                "duration {degenerate} is not a length"
+            );
+            assert!(p.live, "duration {degenerate} must map to live");
+        }
     }
 }

--- a/src-tauri/src/media_controls/windows.rs
+++ b/src-tauri/src/media_controls/windows.rs
@@ -3,7 +3,8 @@
 
 use super::{MainThreadDispatch, MediaControlCallback, NowPlayingPlan, PlaybackState};
 use crate::now_playing::NowPlaying;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, ReentrantMutex};
+use std::cell::RefCell;
 use std::ffi::c_void;
 use std::io::Cursor;
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -11,11 +12,14 @@ use std::time::Duration;
 use windows::core::{factory, w, Ref, HSTRING};
 use windows::Foundation::{TimeSpan, TypedEventHandler, Uri};
 use windows::Media::{
-    MediaPlaybackStatus, MediaPlaybackType, SystemMediaTransportControls,
-    SystemMediaTransportControlsButton, SystemMediaTransportControlsButtonPressedEventArgs,
-    SystemMediaTransportControlsDisplayUpdater, SystemMediaTransportControlsTimelineProperties,
+    MediaPlaybackStatus, MediaPlaybackType, PlaybackPositionChangeRequestedEventArgs,
+    SystemMediaTransportControls, SystemMediaTransportControlsButton,
+    SystemMediaTransportControlsButtonPressedEventArgs, SystemMediaTransportControlsDisplayUpdater,
+    SystemMediaTransportControlsTimelineProperties,
 };
-use windows::Storage::Streams::RandomAccessStreamReference;
+use windows::Storage::Streams::{
+    DataWriter, InMemoryRandomAccessStream, RandomAccessStreamReference,
+};
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, RPC_E_CHANGED_MODE, WPARAM};
 use windows::Win32::Graphics::Gdi::{
     CreateBitmap, DeleteObject, GetSysColor, COLOR_BTNTEXT, HGDIOBJ,
@@ -36,9 +40,50 @@ use windows::Win32::UI::WindowsAndMessaging::{
     WM_SETTINGCHANGE, WM_SYSCOLORCHANGE, WM_THEMECHANGED,
 };
 
-static STATE: Mutex<Option<WindowsMediaControls>> = Mutex::new(None);
+/// All access happens on the Tauri UI thread (via `dispatch`), but that thread
+/// is an STA: any SMTC/COM call may pump window messages, and the taskbar
+/// subclass proc then re-enters this module *while an update is in progress*.
+/// A `ReentrantMutex` + `RefCell` makes that re-entrancy explicit: the nested
+/// call relocks fine (where a plain `Mutex` would deadlock), and
+/// `with_state_mut` detects the still-active mutable borrow and defers.
+static STATE: ReentrantMutex<RefCell<Option<WindowsMediaControls>>> =
+    ReentrantMutex::new(RefCell::new(None));
 static CALLBACK: Mutex<Option<MediaControlCallback>> = Mutex::new(None);
 static DISPATCH: Mutex<Option<MainThreadDispatch>> = Mutex::new(None);
+
+/// Events that could not run because the state was mutably borrowed at the
+/// time (re-entrant message delivery during an update). Producers set flags;
+/// [`with_state_mut`] drains them once the active borrow ends, so nothing is
+/// permanently lost — a dropped `TaskbarButtonCreated` in particular would
+/// otherwise lose the thumbbar buttons for the whole Explorer session.
+#[derive(Default)]
+struct PendingEvents {
+    taskbar_created: bool,
+    theme_changed: bool,
+    reassert_timeline: bool,
+}
+
+impl PendingEvents {
+    fn is_empty(&self) -> bool {
+        !(self.taskbar_created || self.theme_changed || self.reassert_timeline)
+    }
+}
+
+static PENDING_EVENTS: Mutex<PendingEvents> = Mutex::new(PendingEvents {
+    taskbar_created: false,
+    theme_changed: false,
+    reassert_timeline: false,
+});
+
+/// The registered "`TaskbarButtonCreated`" message id, mirrored into a static so
+/// the subclass proc can recognize the message without touching STATE (the
+/// message can arrive re-entrantly while STATE is borrowed). Zero = unset;
+/// `RegisterWindowMessageW` ids are process-wide constants, so mirroring is
+/// safe across rebinds.
+static TASKBAR_CREATED_MSG: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Bundled fallback artwork shown when the current item has no cover.
+const DEFAULT_ART_PNG: &[u8] = include_bytes!("../../resources/logo.png");
 
 const THUMB_PREVIOUS_ID: u32 = 1;
 const THUMB_PLAY_PAUSE_ID: u32 = 2;
@@ -57,8 +102,12 @@ struct WindowsMediaControls {
     display_updater: SystemMediaTransportControlsDisplayUpdater,
     timeline: SystemMediaTransportControlsTimelineProperties,
     button_token: i64,
+    position_token: i64,
     thumbbar: Option<TaskbarThumbnailControls>,
     last_metadata: Option<MetadataKey>,
+    /// Whether the display is already in the cleared/Stopped state, so
+    /// repeated Stopped updates don't re-run the full ClearAll/Update cycle.
+    cleared: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -102,13 +151,25 @@ pub fn init(
 
     let hwnd_addr = hwnd as usize;
     dispatch(move || {
-        if STATE.lock().is_some() {
+        if STATE.lock().borrow().is_some() {
             return;
         }
 
         match WindowsMediaControls::new(hwnd_addr as *mut c_void) {
-            Ok(controls) => {
-                *STATE.lock() = Some(controls);
+            Ok(mut controls) => {
+                render_current_state(&mut controls);
+                // `new()` makes COM calls that can pump messages; a nested
+                // pump could have run a rebind meanwhile. Never overwrite a
+                // newer binding with one made for a possibly-dying window.
+                let guard = STATE.lock();
+                let mut slot = guard.borrow_mut();
+                if slot.is_none() {
+                    *slot = Some(controls);
+                } else {
+                    log::debug!(
+                        "[MediaControls] Windows SMTC already bound during init; keeping newer binding"
+                    );
+                }
             }
             Err(e) => {
                 log::error!("[MediaControls] Failed to initialize Windows SMTC: {e:?}");
@@ -117,12 +178,61 @@ pub fn init(
     });
 }
 
+/// Render the current now-playing state onto freshly bound controls, so the
+/// flyout and button enablement don't stay blank/disabled until the next
+/// frontend push (which can be a while away when paused or idle).
+fn render_current_state(controls: &mut WindowsMediaControls) {
+    let np = crate::now_playing::get_now_playing();
+    let plan = super::plan(&np);
+    if let Err(e) = controls.update(&plan) {
+        log::warn!("[MediaControls] Failed to render onto freshly bound SMTC: {e:?}");
+    }
+}
+
+/// Re-bind SMTC (and the taskbar thumbnail controls) to a new native window.
+///
+/// The SMTC instance obtained through `GetForWindow` lives and dies with its
+/// HWND. Logout and server-switch flows destroy the window we bound at init
+/// and create a replacement — without re-binding, media keys and the SMTC
+/// flyout silently stop working for the rest of the process lifetime.
+/// No-op until [`init`] has run (init will bind to the then-current window).
+pub fn rebind(hwnd_param: Option<*mut c_void>) {
+    if CALLBACK.lock().is_none() {
+        return;
+    }
+    let Some(hwnd) = hwnd_param else {
+        log::warn!("[MediaControls] Cannot re-bind Windows SMTC (no HWND available)");
+        return;
+    };
+
+    let hwnd_addr = hwnd as usize;
+    dispatch(move || {
+        // Tear the old binding down outside any active borrow: Drop makes COM
+        // calls that can pump messages and re-enter this module. This may run
+        // after the old window is already destroyed, which is fine: the SMTC
+        // COM object is decoupled from the HWND, and `RemoveWindowSubclass`
+        // on a dead HWND is a benign no-op (comctl32 detaches subclasses at
+        // WM_NCDESTROY).
+        let old = STATE.lock().borrow_mut().take();
+        drop(old);
+
+        match WindowsMediaControls::new(hwnd_addr as *mut c_void) {
+            Ok(mut controls) => {
+                render_current_state(&mut controls);
+                *STATE.lock().borrow_mut() = Some(controls);
+            }
+            Err(e) => {
+                log::error!("[MediaControls] Failed to re-bind Windows SMTC: {e:?}");
+            }
+        }
+    });
+}
+
 pub fn update(np: &NowPlaying) {
     let plan = super::plan(np);
-    let np = np.clone();
     dispatch(move || {
         with_state_mut(|controls| {
-            if let Err(e) = controls.update(&plan, &np) {
+            if let Err(e) = controls.update(&plan) {
                 log::error!("[MediaControls] Failed to update Windows SMTC: {e:?}");
             }
         });
@@ -147,15 +257,68 @@ fn dispatch(f: impl FnOnce() + Send + 'static) {
 }
 
 fn with_state_mut(f: impl FnOnce(&mut WindowsMediaControls)) {
-    let Some(mut controls) = STATE.lock().take() else {
-        return;
-    };
-    f(&mut controls);
-    *STATE.lock() = Some(controls);
+    let guard = STATE.lock();
+    let borrow = guard.try_borrow_mut();
+    match borrow {
+        Ok(mut slot) => {
+            if let Some(controls) = slot.as_mut() {
+                f(controls);
+            }
+            // Drain events that were recorded (instead of handled) because
+            // they arrived re-entrantly while a borrow was active — including
+            // any recorded during `f` itself just now.
+            loop {
+                let pending = std::mem::take(&mut *PENDING_EVENTS.lock());
+                if pending.is_empty() {
+                    break;
+                }
+                let Some(controls) = slot.as_mut() else {
+                    break;
+                };
+                if pending.taskbar_created {
+                    if let Some(thumbbar) = controls.thumbbar.as_mut() {
+                        thumbbar.on_taskbar_button_created();
+                    }
+                }
+                if pending.theme_changed {
+                    if let Some(thumbbar) = controls.thumbbar.as_mut() {
+                        thumbbar.refresh_icon_theme();
+                    }
+                }
+                if pending.reassert_timeline {
+                    if let Err(e) = controls
+                        .controls
+                        .UpdateTimelineProperties(&controls.timeline)
+                    {
+                        log::warn!(
+                            "[MediaControls] Failed to re-assert Windows SMTC position: {e:?}"
+                        );
+                    }
+                }
+            }
+        }
+        // Re-entrant access while an update is already borrowing the state
+        // (STA message pumping). Callers that must not lose their event have
+        // recorded it in PENDING_EVENTS; the outer holder drains it.
+        Err(_) => {
+            log::debug!("[MediaControls] Deferred re-entrant Windows SMTC state access");
+        }
+    }
 }
 
 impl WindowsMediaControls {
     fn new(hwnd: *mut c_void) -> windows::core::Result<Self> {
+        // Tauri/Wry initializes COM for the UI thread in normal operation. If
+        // it has not yet done so, initialize this long-lived UI thread as STA
+        // before the first WinRT factory/interop call below (rather than
+        // relying on the host having beaten us to it); we intentionally do not
+        // CoUninitialize during process lifetime. Ignore RPC_E_CHANGED_MODE
+        // because an existing MTA is still usable.
+        let init_result = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+        if init_result.is_err() && init_result != RPC_E_CHANGED_MODE {
+            log::debug!("[MediaControls] CoInitializeEx for SMTC returned {init_result:?}");
+        }
+
         let interop: ISystemMediaTransportControlsInterop =
             factory::<SystemMediaTransportControls, ISystemMediaTransportControlsInterop>()?;
         // Tauri gives us a Win32 HWND, not a UWP/CoreWindow view. SMTC needs the
@@ -165,12 +328,16 @@ impl WindowsMediaControls {
         let timeline = SystemMediaTransportControlsTimelineProperties::new()?;
 
         controls.SetIsEnabled(true)?;
-        controls.SetIsPlayEnabled(true)?;
-        controls.SetIsPauseEnabled(true)?;
-        controls.SetIsStopEnabled(true)?;
-        controls.SetIsNextEnabled(true)?;
-        controls.SetIsPreviousEnabled(true)?;
+        // Buttons start disabled; enablement is driven per update from the
+        // item's capabilities. (Fast-forward/rewind/record/channel buttons are
+        // never enabled — the `windows` crate defaults already leave them off.)
+        controls.SetIsPlayEnabled(false)?;
+        controls.SetIsPauseEnabled(false)?;
+        controls.SetIsStopEnabled(false)?;
+        controls.SetIsNextEnabled(false)?;
+        controls.SetIsPreviousEnabled(false)?;
         display_updater.SetType(MediaPlaybackType::Music)?;
+        display_updater.SetAppMediaId(&HSTRING::from("io.music-assistant.companion"))?;
 
         let button_handler = TypedEventHandler::new(
             move |_sender: Ref<'_, SystemMediaTransportControls>,
@@ -184,6 +351,23 @@ impl WindowsMediaControls {
             },
         );
         let button_token = controls.ButtonPressed(&button_handler)?;
+
+        // There is no seek path to the frontend, so honor the SMTC contract's
+        // second option for position-change requests: ignore the request but
+        // re-assert the real position, so the flyout scrubber snaps back
+        // instead of silently lying about a seek that never happened. The
+        // work is recorded as a pending event and handled through the drain
+        // loop so it survives arriving while the state is borrowed.
+        let position_handler = TypedEventHandler::new(
+            move |_sender: Ref<'_, SystemMediaTransportControls>,
+                  _args: Ref<'_, PlaybackPositionChangeRequestedEventArgs>| {
+                PENDING_EVENTS.lock().reassert_timeline = true;
+                dispatch(|| with_state_mut(|_| {}));
+                Ok(())
+            },
+        );
+        let position_token = controls.PlaybackPositionChangeRequested(&position_handler)?;
+
         let thumbbar = match TaskbarThumbnailControls::new(HWND(hwnd)) {
             Ok(thumbbar) => Some(thumbbar),
             Err(e) => {
@@ -197,20 +381,26 @@ impl WindowsMediaControls {
             display_updater,
             timeline,
             button_token,
+            position_token,
             thumbbar,
             last_metadata: None,
+            cleared: false,
         })
     }
 
-    fn update(&mut self, plan: &NowPlayingPlan, np: &NowPlaying) -> windows::core::Result<()> {
-        self.controls
-            .SetIsPlayEnabled(np.can_play || !np.is_playing)?;
-        self.controls
-            .SetIsPauseEnabled(np.can_pause || np.is_playing)?;
-        self.controls.SetIsNextEnabled(np.can_next)?;
-        self.controls.SetIsPreviousEnabled(np.can_previous)?;
+    fn update(&mut self, plan: &NowPlayingPlan) -> windows::core::Result<()> {
+        // `plan.can_play`/`can_pause` are state-independent item capabilities
+        // (shared mapping); next/previous come from the queue flags; stop is
+        // meaningful whenever a track is loaded. `plan.rate` is deliberately
+        // unused here: SMTC has no playback-rate property to feed, and
+        // PlaybackStatus already conveys playing/paused.
+        self.controls.SetIsPlayEnabled(plan.can_play)?;
+        self.controls.SetIsPauseEnabled(plan.can_pause)?;
+        self.controls.SetIsStopEnabled(plan.title.is_some())?;
+        self.controls.SetIsNextEnabled(plan.can_next)?;
+        self.controls.SetIsPreviousEnabled(plan.can_previous)?;
         if let Some(thumbbar) = &mut self.thumbbar {
-            if let Err(e) = thumbbar.update(np) {
+            if let Err(e) = thumbbar.update(plan) {
                 log::warn!(
                     "[MediaControls] Failed to update Windows taskbar thumbnail controls: {e:?}"
                 );
@@ -220,6 +410,7 @@ impl WindowsMediaControls {
         if plan.state == PlaybackState::Stopped {
             return self.clear();
         }
+        self.cleared = false;
 
         let metadata = MetadataKey::from_plan(plan);
         if self.last_metadata.as_ref() != Some(&metadata) {
@@ -227,24 +418,44 @@ impl WindowsMediaControls {
             self.last_metadata = Some(metadata);
         }
 
-        let start = TimeSpan::default();
-        let end = plan
-            .duration_secs
-            .and_then(seconds_to_timespan)
-            .unwrap_or(start);
-        self.timeline.SetStartTime(start)?;
-        self.timeline.SetMinSeekTime(start)?;
-        self.timeline.SetEndTime(end)?;
-        self.timeline.SetMaxSeekTime(end)?;
-        self.timeline.SetPosition(
-            plan.elapsed_secs
+        // A timeline is only valid for an item with a known finite length:
+        // TimelineProperties defines Position as bounded by Start/EndTime, and
+        // a Position past EndTime renders a glitched progress bar. Live and
+        // unknown-length streams (duration absent) get a zeroed timeline,
+        // which hides the progress bar entirely.
+        if let Some(duration) = plan.duration_secs.filter(|d| d.is_finite() && *d > 0.0) {
+            let start = TimeSpan::default();
+            let end = seconds_to_timespan(duration).unwrap_or(start);
+            let position = plan
+                .elapsed_secs
+                // NaN would slip through `min` (f64::min ignores NaN and
+                // would pin the position to the end of the track).
+                .filter(|elapsed| elapsed.is_finite())
+                .map(|elapsed| elapsed.min(duration))
                 .and_then(seconds_to_timespan)
-                .unwrap_or(start),
-        )?;
+                .unwrap_or(start);
+            self.timeline.SetStartTime(start)?;
+            self.timeline.SetMinSeekTime(start)?;
+            self.timeline.SetEndTime(end)?;
+            self.timeline.SetMaxSeekTime(end)?;
+            self.timeline.SetPosition(position)?;
+        } else {
+            self.reset_timeline()?;
+        }
 
         self.controls.UpdateTimelineProperties(&self.timeline)?;
         self.controls
             .SetPlaybackStatus(playback_status(plan.state))?;
+        Ok(())
+    }
+
+    fn reset_timeline(&self) -> windows::core::Result<()> {
+        let reset = TimeSpan::default();
+        self.timeline.SetStartTime(reset)?;
+        self.timeline.SetMinSeekTime(reset)?;
+        self.timeline.SetEndTime(reset)?;
+        self.timeline.SetMaxSeekTime(reset)?;
+        self.timeline.SetPosition(reset)?;
         Ok(())
     }
 
@@ -262,33 +473,48 @@ impl WindowsMediaControls {
         Ok(())
     }
 
+    /// Point the display updater at the item's cover, or the bundled app logo
+    /// when there is none. Remote URIs are fetched lazily by the shell when
+    /// the flyout renders, so a failing fetch is invisible here — only
+    /// synchronous URI/factory errors surface, and then the default art is
+    /// used instead of leaving the tile empty after `ClearAll()`.
     fn set_thumbnail(&self, url: Option<&str>) {
-        let Some(url) = url else {
-            return;
-        };
+        if let Some(url) = url {
+            let result = Uri::CreateUri(&HSTRING::from(url))
+                .and_then(|uri| RandomAccessStreamReference::CreateFromUri(&uri))
+                .and_then(|stream| self.display_updater.SetThumbnail(&stream));
+            match result {
+                Ok(()) => return,
+                Err(e) => log::warn!(
+                    "[MediaControls] Failed to set Windows SMTC thumbnail for {url}: {e:?}"
+                ),
+            }
+        }
 
-        let result = Uri::CreateUri(&HSTRING::from(url))
-            .and_then(|uri| RandomAccessStreamReference::CreateFromUri(&uri))
-            .and_then(|stream| self.display_updater.SetThumbnail(&stream));
-        if let Err(e) = result {
-            log::warn!("[MediaControls] Failed to set Windows SMTC thumbnail for {url}: {e:?}");
+        if let Some(default) = default_thumbnail() {
+            if let Err(e) = self.display_updater.SetThumbnail(&default) {
+                log::warn!("[MediaControls] Failed to set default SMTC thumbnail: {e:?}");
+            }
         }
     }
 
+    /// Empty the display and report `Stopped`. Deliberately not `Closed`:
+    /// `Stopped` keeps the (empty) session registered so media keys can still
+    /// reach us for a resume, while `Closed` would remove the app from the
+    /// SMTC session list entirely — that is reserved for teardown in `Drop`.
     fn clear(&mut self) -> windows::core::Result<()> {
+        if self.cleared {
+            return Ok(());
+        }
         self.display_updater.ClearAll()?;
         self.display_updater.SetType(MediaPlaybackType::Music)?;
         self.display_updater.Update()?;
         self.last_metadata = None;
         self.controls
             .SetPlaybackStatus(MediaPlaybackStatus::Stopped)?;
-        let reset = TimeSpan::default();
-        self.timeline.SetStartTime(reset)?;
-        self.timeline.SetMinSeekTime(reset)?;
-        self.timeline.SetEndTime(reset)?;
-        self.timeline.SetMaxSeekTime(reset)?;
-        self.timeline.SetPosition(reset)?;
+        self.reset_timeline()?;
         self.controls.UpdateTimelineProperties(&self.timeline)?;
+        self.cleared = true;
         Ok(())
     }
 }
@@ -296,15 +522,45 @@ impl WindowsMediaControls {
 impl Drop for WindowsMediaControls {
     fn drop(&mut self) {
         let _ = self.controls.RemoveButtonPressed(self.button_token);
+        let _ = self
+            .controls
+            .RemovePlaybackPositionChangeRequested(self.position_token);
         let _ = self.controls.SetIsEnabled(false);
         let _ = self.controls.SetPlaybackStatus(MediaPlaybackStatus::Closed);
     }
 }
 
+/// The fallback thumbnail (bundled app logo), built once per process:
+/// `RandomAccessStreamReference` is a cheap cloneable handle, and rebuilding
+/// the in-memory stream on every bind/rebind would be wasted work.
+fn default_thumbnail() -> Option<RandomAccessStreamReference> {
+    static DEFAULT_THUMBNAIL: std::sync::OnceLock<Option<RandomAccessStreamReference>> =
+        std::sync::OnceLock::new();
+    DEFAULT_THUMBNAIL
+        .get_or_init(|| match build_default_thumbnail() {
+            Ok(thumbnail) => Some(thumbnail),
+            Err(e) => {
+                log::warn!("[MediaControls] Failed to build default SMTC thumbnail: {e:?}");
+                None
+            }
+        })
+        .clone()
+}
+
+/// Build an in-memory stream reference around the bundled app logo.
+fn build_default_thumbnail() -> windows::core::Result<RandomAccessStreamReference> {
+    let stream = InMemoryRandomAccessStream::new()?;
+    let writer = DataWriter::CreateDataWriter(&stream)?;
+    writer.WriteBytes(DEFAULT_ART_PNG)?;
+    writer.StoreAsync()?.get()?;
+    writer.DetachStream()?;
+    stream.Seek(0)?;
+    RandomAccessStreamReference::CreateFromStream(&stream)
+}
+
 struct TaskbarThumbnailControls {
     hwnd: HWND,
     taskbar: ITaskbarList3,
-    taskbar_button_created_msg: u32,
     icons: ThumbIcons,
     icon_theme: ThumbIconTheme,
     buttons_added: bool,
@@ -379,16 +635,8 @@ fn destroy_icon(icon: HICON) {
 
 impl TaskbarThumbnailControls {
     fn new(hwnd: HWND) -> windows::core::Result<Self> {
-        // Tauri/Wry initializes COM for the UI thread in normal operation. If it
-        // has not yet done so, initialize this long-lived UI thread as STA for
-        // shell APIs; we intentionally do not CoUninitialize it during process
-        // lifetime. Ignore RPC_E_CHANGED_MODE because an existing MTA is still
-        // usable for CoCreateInstance below.
-        let init_result = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
-        if init_result.is_err() && init_result != RPC_E_CHANGED_MODE {
-            log::debug!("[MediaControls] CoInitializeEx for ThumbBar returned {init_result:?}");
-        }
-
+        // COM apartment initialization happens in `WindowsMediaControls::new`,
+        // before the first WinRT call of the whole backend.
         let taskbar: ITaskbarList3 =
             unsafe { CoCreateInstance(&TaskbarList, None, CLSCTX_INPROC_SERVER) }?;
         unsafe { taskbar.HrInit()? };
@@ -397,12 +645,16 @@ impl TaskbarThumbnailControls {
         if taskbar_button_created_msg == 0 {
             return Err(windows::core::Error::from_win32());
         }
+        // Mirror for the subclass proc (see TASKBAR_CREATED_MSG).
+        TASKBAR_CREATED_MSG.store(
+            taskbar_button_created_msg,
+            std::sync::atomic::Ordering::Relaxed,
+        );
         let icon_theme = current_icon_theme();
         let icons = ThumbIcons::new(icon_theme)?;
         let mut controls = Self {
             hwnd,
             taskbar,
-            taskbar_button_created_msg,
             icons,
             icon_theme,
             buttons_added: false,
@@ -418,12 +670,12 @@ impl TaskbarThumbnailControls {
         Ok(controls)
     }
 
-    fn update(&mut self, np: &NowPlaying) -> windows::core::Result<()> {
+    fn update(&mut self, plan: &NowPlayingPlan) -> windows::core::Result<()> {
         let state = ThumbButtonState {
-            previous_enabled: np.can_previous,
-            play_pause_enabled: np.can_play || np.can_pause || np.is_playing,
-            use_pause: np.is_playing,
-            next_enabled: np.can_next,
+            previous_enabled: plan.can_previous,
+            play_pause_enabled: plan.can_play || plan.can_pause,
+            use_pause: plan.state == PlaybackState::Playing,
+            next_enabled: plan.can_next,
         };
         self.update_buttons(state)
     }
@@ -542,27 +794,21 @@ unsafe extern "system" fn taskbar_subclass_proc(
     _subclass_id: usize,
     _ref_data: usize,
 ) -> LRESULT {
-    let taskbar_button_created_msg = STATE
-        .lock()
-        .as_ref()
-        .and_then(|state| state.thumbbar.as_ref())
-        .map(|controls| controls.taskbar_button_created_msg);
-
-    if taskbar_button_created_msg == Some(msg) {
-        with_state_mut(|state| {
-            if let Some(thumbbar) = state.thumbbar.as_mut() {
-                thumbbar.on_taskbar_button_created();
-            }
-        });
+    // Record the event first, then poke `with_state_mut` with a no-op: if the
+    // state is free the drain loop handles the event immediately; if the
+    // state is mutably borrowed (re-entrant delivery during an update), the
+    // flag survives and the outer borrow holder drains it when done. The
+    // message id comes from a static mirror so recognizing it never needs the
+    // (possibly borrowed) state.
+    let taskbar_created_msg = TASKBAR_CREATED_MSG.load(std::sync::atomic::Ordering::Relaxed);
+    if taskbar_created_msg != 0 && msg == taskbar_created_msg {
+        PENDING_EVENTS.lock().taskbar_created = true;
+        with_state_mut(|_| {});
         return LRESULT(0);
     }
-
     if matches!(msg, WM_SETTINGCHANGE | WM_SYSCOLORCHANGE | WM_THEMECHANGED) {
-        with_state_mut(|state| {
-            if let Some(thumbbar) = state.thumbbar.as_mut() {
-                thumbbar.refresh_icon_theme();
-            }
-        });
+        PENDING_EVENTS.lock().theme_changed = true;
+        with_state_mut(|_| {});
     }
 
     if msg == WM_COMMAND && command_notification(wparam) == THBN_CLICKED {
@@ -673,7 +919,7 @@ fn icon_from_mask(mask_png: &[u8], color: (u8, u8, u8)) -> windows::core::Result
         hbmMask: hbm_mask,
         hbmColor: hbm_color,
     };
-    let icon = unsafe { CreateIconIndirect(&icon_info) };
+    let icon = unsafe { CreateIconIndirect(&raw const icon_info) };
     let _ = unsafe { DeleteObject(HGDIOBJ(hbm_mask.0)) };
     let _ = unsafe { DeleteObject(HGDIOBJ(hbm_color.0)) };
     icon
@@ -815,8 +1061,16 @@ where
 }
 
 fn seconds_to_timespan(seconds: f64) -> Option<TimeSpan> {
+    // `try_from_secs_f64` (unlike `from_secs_f64`) rejects values that
+    // overflow a Duration instead of panicking; the values come from
+    // frontend/server JSON, so hostile-but-finite input must not panic the
+    // UI thread. Also cap at 30 days so a garbage value cannot overflow the
+    // TimeSpan's i64 100-ns units downstream.
+    const MAX_TIMELINE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
     if seconds.is_finite() && seconds >= 0.0 {
-        Some(TimeSpan::from(Duration::from_secs_f64(seconds)))
+        Duration::try_from_secs_f64(seconds)
+            .ok()
+            .map(|duration| TimeSpan::from(duration.min(MAX_TIMELINE)))
     } else {
         None
     }


### PR DESCRIPTION
Shared plan() (all platforms):
- CanPlay/CanPause are intrinsic to the current item and no longer flip with playback state (MPRIS forbids deriving them from PlaybackStatus, and GNOME Shell drops the media card when CanPlay goes false).
- Next/previous are masked when no track is loaded.
- Non-positive/non-finite durations normalize to "no known length" so live/unknown streams get the proper UI instead of a zero-length track.
- OS media commands are logged at info level.

Linux (MPRIS):
- Position extrapolates from the last report while playing, clamps to [0, mpris:length], and advertises EmitsChangedSignal=false.
- Position jumps inconsistent with Rate-based extrapolation emit the previously missing Seeked signal; the jump detector tolerates upstream reporting jitter around play/pause transitions.
- PropertiesChanged emissions are diffed against the previous state so progress ticks no longer rebroadcast unchanged properties; the ledger only advances on successful emission so transient D-Bus failures retry.
- Volume is served from a listener-driven cache instead of a getter-side read-through, fixing the slider snap-back after SetVolume.
- Raise shows and focuses the main window; CanRaise is true.
- Unsupported writable properties (LoopStatus, Shuffle, Fullscreen) return NotSupported; Rate=0.0 acts as Pause per spec.
- mpris:artUrl only passes through http/https/file URLs.
- A failed service start clears the command channel instead of leaving a zombie sender that warned on every update.

macOS (Now Playing):
- MPNowPlayingInfoCenter.playbackState is set on every render and on clear; it (not the playback rate) is what drives Control Center state and media-key routing.
- Remote-command enablement is driven per update from item capabilities, cleared with the item, and handlers report NoActionableNowPlayingItem when nothing is playable.
- MediaType (Audio), DefaultPlaybackRate, and IsLiveStream are set.
- Artwork honors the requested size, uses the image's natural bounds, omits undecodable covers, and is cached per cover (ABA-safe).
- The plan publishes before the cover fetch starts so a near-instant fetch cannot pair the old plan with new artwork.
- Cover fetching supports data: (strict base64) and file: URLs.

Windows (SMTC):
- SMTC and the taskbar thumbbar re-bind across window recreation (logout/server switch); media keys and the flyout previously died silently for the rest of the process.
- State lives in a ReentrantMutex<RefCell<...>> with a pending-event drain, since STA message pumping re-enters the subclass proc mid update; a dropped TaskbarButtonCreated lost the thumbbar until the next Explorer restart.
- Timelines are only published for items with a known finite length, positions clamp to the duration, and timeline conversion rejects values that would overflow or panic.
- PlaybackPositionChangeRequested re-asserts the true position so the scrubber snaps back instead of lying (no seek path exists).
- Button enablement follows item capabilities, buttons start disabled until the bind-time render, and the flyout falls back to the bundled logo when the item has no usable cover.
- CoInitializeEx is hoisted before the first WinRT factory call.