### PR TITLE
fix: never install a duplicate when the WiX/MSI migration is declined

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,6 +37,11 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "nsis": {
+        "installerHooks": "./windows/hooks.nsi"
+      }
+    }
   }
 }

--- a/src-tauri/windows/hooks.nsi
+++ b/src-tauri/windows/hooks.nsi
@@ -1,0 +1,44 @@
+; Installer hooks for Tauri's NSIS template (bundle.windows.nsis.installerHooks).
+;
+; Guard against a duplicated install when migrating from the legacy WiX/MSI
+; package. The template's reinstall page runs the MSI's interactive
+; uninstaller, but if the user cancels it (or it fails), the page's Abort is
+; swallowed in passive/update mode — the mode the in-app updater uses — and
+; installation proceeds anyway, leaving both an MSI and an NSIS copy
+; registered. This hook runs at the top of the install section, before any
+; file is written: re-check for a surviving MSI registration, retry the
+; uninstall without the confirmation dialog, and if the product still cannot
+; be removed, quit without installing anything.
+!macro NSIS_HOOK_PREINSTALL
+  StrCpy $0 0
+  hook_wix_loop:
+    EnumRegKey $1 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" $0
+    StrCmp $1 "" hook_wix_done
+    IntOp $0 $0 + 1
+    ReadRegStr $2 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1" "DisplayName"
+    ReadRegStr $3 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1" "Publisher"
+    StrCmp "$2$3" "${PRODUCTNAME}${MANUFACTURER}" 0 hook_wix_loop
+    ReadRegDWORD $2 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1" "WindowsInstaller"
+    IntCmp $2 1 0 hook_wix_loop hook_wix_loop
+
+    ; $1 is the product code GUID (the key name for MSI registrations).
+    ; /passive shows only a progress bar: no confirmation dialog to cancel.
+    DetailPrint "Removing previously installed ${PRODUCTNAME} (MSI)"
+    ClearErrors
+    ExecWait 'msiexec.exe /X$1 /passive /norestart' $2
+    ${If} ${Errors}
+      StrCpy $2 2 ; ExecWait itself failed; fake a nonzero exit code
+    ${EndIf}
+    ${If} $2 = 0     ; removed
+    ${OrIf} $2 = 3010 ; removed, reboot required
+    ${OrIf} $2 = 1605 ; already gone
+      Goto hook_wix_done
+    ${EndIf}
+
+    ; Still installed: do NOT proceed, or we would create a duplicate.
+    IfSilent +2
+    MessageBox MB_ICONEXCLAMATION "$(unableToUninstall)"
+    SetErrorLevel $2
+    Quit
+  hook_wix_done:
+!macroend


### PR DESCRIPTION
The NSIS template's reinstall page runs the legacy MSI's uninstaller interactively during WiX migration. If the user cancels it (or it fails), the page's Abort is swallowed in passive/update mode - the mode the in-app updater uses - and installation proceeds anyway, leaving both an MSI and an NSIS copy registered (issue #161's duplication, with the roles swapped). Reproduced live against the released 0.6.3 MSI and 0.6.4 NSIS artifacts.

Add an NSIS_HOOK_PREINSTALL hook (a supported tauri-bundler extension point, so no template fork): it runs at the top of the install section, before any file is written. If an MSI registration of this product survived the reinstall page, retry the uninstall with /passive - a progress bar with no cancelable confirmation dialog - and if the product still cannot be removed, quit without installing anything. Worst case becomes 'the update did not happen this time' instead of a duplicated install.