### PR TITLE
feat(linux): inhibit sleep and screen-off during playback

### DIFF
--- a/packaging/flatpak/io.music_assistant.Companion.yml
+++ b/packaging/flatpak/io.music_assistant.Companion.yml
@@ -31,6 +31,14 @@ finish-args:
   # of the canonical application ID and appends a per-instance suffix.
   - --own-name=org.mpris.MediaPlayer2.io_music_assistant_companion.*
 
+  # Keep the display awake and block automatic suspend while playback is active.
+  # The app prefers the XDG desktop portal (org.freedesktop.portal.Inhibit with
+  # the SUSPEND | IDLE flags), which needs no extra sandbox permission. This
+  # org.freedesktop.ScreenSaver name is only the fallback for sessions without a
+  # working portal — there it at least keeps the screen on and unlocked, but on
+  # KDE a ScreenSaver inhibition does not stop idle auto-suspend.
+  - --talk-name=org.freedesktop.ScreenSaver
+
   # Tauri single-instance uses tauri.conf.json's identifier, transformed for D-Bus.
   # `own` is the highest D-Bus policy level and includes talking to the name;
   # do not also add `--talk-name` for the same key or Flatpak metadata records

--- a/src-tauri/src/now_playing.rs
+++ b/src-tauri/src/now_playing.rs
@@ -80,9 +80,240 @@ mod power_management {
     }
 }
 
+/// Linux idle / sleep inhibition for active playback.
+///
+/// Prefers the XDG desktop portal's `org.freedesktop.portal.Inhibit` interface
+/// with the `SUSPEND | IDLE` flags. Unlike a bare `org.freedesktop.ScreenSaver`
+/// inhibition — which on KDE Plasma only maps to the `ChangeScreenSettings`
+/// power-management policy, blocking screen-blanking and the lock but never
+/// automatic suspend — the portal backends translate those flags into a full
+/// set of inhibitions on every desktop (on KDE, `InterruptSession` +
+/// `ChangeScreenSettings`). The portal is also always reachable from inside a
+/// Flatpak sandbox without any extra permission.
+///
+/// Where the portal is unavailable (older or minimal non-Flatpak sessions) it
+/// falls back to `org.freedesktop.ScreenSaver`, which still keeps the screen on
+/// and unlocked but, on KDE, does not stop idle auto-suspend.
+///
+/// A deliberate, user-initiated suspend is always still allowed.
+///
+/// Like the Windows backend, the inhibition handle is owned by a dedicated
+/// worker thread and playback-state changes are forwarded to it over a
+/// channel; only the latest state matters, so bursts of metadata / progress
+/// updates are coalesced.
+#[cfg(target_os = "linux")]
+mod power_management {
+    use super::{get_now_playing, on_now_playing_change};
+    use std::collections::HashMap;
+    use std::sync::{mpsc, Arc, Once};
+    use std::thread;
+    use zbus::blocking::{Connection, Proxy};
+    use zbus::zvariant::{OwnedObjectPath, Value};
+
+    static START: Once = Once::new();
+
+    /// Name shown to the user by the desktop's "applications currently
+    /// preventing sleep" UI.
+    const APP_NAME: &str = "Music Assistant";
+    const REASON: &str = "Playing media";
+
+    /// XDG desktop portal — reachable unchanged from inside a Flatpak sandbox.
+    const PORTAL_NAME: &str = "org.freedesktop.portal.Desktop";
+    const PORTAL_PATH: &str = "/org/freedesktop/portal/desktop";
+    const PORTAL_INHIBIT_INTERFACE: &str = "org.freedesktop.portal.Inhibit";
+    const PORTAL_REQUEST_INTERFACE: &str = "org.freedesktop.portal.Request";
+
+    /// `SUSPEND` (4) | `IDLE` (8) from the portal's inhibit flags — together
+    /// they cover idle screen-blanking, the screen lock, and idle auto-suspend.
+    const PORTAL_FLAGS: u32 = 4 | 8;
+
+    /// Well-known bus name and interface name (identical) of the screensaver
+    /// service used as a fallback.
+    const SCREENSAVER_NAME: &str = "org.freedesktop.ScreenSaver";
+
+    /// `org.freedesktop.ScreenSaver` is registered at one of these object paths
+    /// depending on the desktop (KDE historically only served `/ScreenSaver`;
+    /// the freedesktop-namespaced path is the modern one and what GNOME uses).
+    /// Probe them in order and keep the first that answers.
+    const SCREENSAVER_PATHS: [&str; 2] = ["/org/freedesktop/ScreenSaver", "/ScreenSaver"];
+
+    /// A currently-held inhibition, tagged by the mechanism that produced it so
+    /// it can be released the same way.
+    enum Inhibition {
+        /// Portal request object, released by calling `Close` on it.
+        Portal(OwnedObjectPath),
+        /// `org.freedesktop.ScreenSaver` cookie, released via `UnInhibit`.
+        ScreenSaver(u32),
+    }
+
+    /// The inhibition mechanism resolved for this session.
+    enum Backend {
+        Portal(Proxy<'static>),
+        ScreenSaver(Proxy<'static>),
+    }
+
+    impl Backend {
+        fn label(&self) -> &'static str {
+            match self {
+                Backend::Portal(_) => "xdg-desktop-portal Inhibit (suspend + idle)",
+                Backend::ScreenSaver(_) => {
+                    "org.freedesktop.ScreenSaver (screen only; no auto-suspend on KDE)"
+                }
+            }
+        }
+
+        /// Take an inhibition. Called on each transition into playback.
+        fn engage(&self) -> zbus::Result<Inhibition> {
+            match self {
+                Backend::Portal(proxy) => {
+                    let mut options: HashMap<&str, Value> = HashMap::new();
+                    options.insert("reason", Value::from(REASON));
+                    let handle = proxy
+                        .call::<_, _, OwnedObjectPath>("Inhibit", &("", PORTAL_FLAGS, options))?;
+                    Ok(Inhibition::Portal(handle))
+                }
+                Backend::ScreenSaver(proxy) => {
+                    let cookie = proxy.call::<_, _, u32>("Inhibit", &(APP_NAME, REASON))?;
+                    Ok(Inhibition::ScreenSaver(cookie))
+                }
+            }
+        }
+
+        /// Release a previously-taken inhibition. The worker only ever pairs a
+        /// backend with an inhibition of its own kind.
+        fn release(&self, connection: &Connection, inhibition: Inhibition) -> zbus::Result<()> {
+            match inhibition {
+                Inhibition::Portal(handle) => {
+                    let request = Proxy::new(
+                        connection,
+                        PORTAL_NAME,
+                        handle.as_str(),
+                        PORTAL_REQUEST_INTERFACE,
+                    )?;
+                    request.call::<_, _, ()>("Close", &())
+                }
+                Inhibition::ScreenSaver(cookie) => {
+                    let Backend::ScreenSaver(proxy) = self else {
+                        return Ok(());
+                    };
+                    proxy.call::<_, _, ()>("UnInhibit", &(cookie,))
+                }
+            }
+        }
+    }
+
+    pub(super) fn init() {
+        START.call_once(|| {
+            let (tx, rx) = mpsc::channel::<()>();
+            thread::spawn(move || run_worker(rx));
+
+            let callback_tx = tx.clone();
+            on_now_playing_change(Arc::new(move |_now_playing| {
+                let _ = callback_tx.send(());
+            }));
+
+            // Playback may have started before desktop services were initialized.
+            let _ = tx.send(());
+        });
+    }
+
+    /// Resolve the best available inhibition mechanism, preferring the portal.
+    /// Returns `None` when nothing is reachable (headless session, a desktop
+    /// without either interface, no session bus).
+    fn resolve_backend(connection: &Connection) -> Option<Backend> {
+        // The portal: probe by reading the `version` property, which confirms
+        // the interface is there without taking (and dropping) a real
+        // inhibition.
+        match Proxy::new(
+            connection,
+            PORTAL_NAME,
+            PORTAL_PATH,
+            PORTAL_INHIBIT_INTERFACE,
+        ) {
+            Ok(proxy) => match proxy.get_property::<u32>("version") {
+                Ok(_) => return Some(Backend::Portal(proxy)),
+                Err(e) => {
+                    log::debug!("[PowerManagement] xdg-desktop-portal Inhibit unavailable: {e}");
+                }
+            },
+            Err(e) => log::debug!("[PowerManagement] Cannot reach the desktop portal: {e}"),
+        }
+
+        // Fallback: org.freedesktop.ScreenSaver. Probe each candidate path by
+        // taking an inhibition and releasing it straight away.
+        for path in SCREENSAVER_PATHS {
+            let Ok(proxy) = Proxy::new(connection, SCREENSAVER_NAME, path, SCREENSAVER_NAME) else {
+                continue;
+            };
+            let backend = Backend::ScreenSaver(proxy);
+            match backend.engage() {
+                Ok(inhibition) => {
+                    let _ = backend.release(connection, inhibition);
+                    log::debug!("[PowerManagement] Using ScreenSaver inhibitor at {path}");
+                    return Some(backend);
+                }
+                Err(e) => log::debug!("[PowerManagement] ScreenSaver at {path} unavailable: {e}"),
+            }
+        }
+        None
+    }
+
+    fn run_worker(rx: mpsc::Receiver<()>) {
+        let connection = match Connection::session() {
+            Ok(connection) => connection,
+            Err(e) => {
+                log::info!("[PowerManagement] No session bus for sleep inhibition: {e}");
+                return;
+            }
+        };
+
+        let Some(backend) = resolve_backend(&connection) else {
+            log::info!("[PowerManagement] No idle/suspend inhibitor available; playback will not keep this system awake");
+            return;
+        };
+        log::debug!(
+            "[PowerManagement] Sleep inhibition backend: {}",
+            backend.label()
+        );
+
+        let mut inhibition: Option<Inhibition> = None;
+
+        while rx.recv().is_ok() {
+            // Coalesce metadata / progress updates; only the latest playback
+            // state matters to the inhibition.
+            while rx.try_recv().is_ok() {}
+            let should_inhibit = get_now_playing().is_playing;
+
+            if should_inhibit == inhibition.is_some() {
+                continue;
+            }
+
+            if should_inhibit {
+                match backend.engage() {
+                    Ok(held) => {
+                        inhibition = Some(held);
+                        log::debug!("[PowerManagement] Linux sleep inhibition enabled");
+                    }
+                    Err(e) => log::warn!("[PowerManagement] Failed to inhibit idle sleep: {e}"),
+                }
+            } else if let Some(held) = inhibition.take() {
+                if let Err(e) = backend.release(&connection, held) {
+                    log::warn!("[PowerManagement] Failed to release sleep inhibition: {e}");
+                }
+                log::debug!("[PowerManagement] Linux sleep inhibition disabled");
+            }
+        }
+
+        // Release the inhibition if the worker is ever shut down cleanly.
+        if let Some(held) = inhibition.take() {
+            let _ = backend.release(&connection, held);
+        }
+    }
+}
+
 /// Start the platform-specific playback power-management integration.
 pub fn init_power_management() {
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     power_management::init();
 }
 


### PR DESCRIPTION
The Linux counterpart to #150. Playback now holds an idle/suspend
inhibition for as long as something is playing, so the machine doesn't
sleep, the display doesn't blank or power off, and the session doesn't
auto-lock mid-track. A deliberate, user-initiated suspend is still
allowed.

Backend selection (session bus, one long-lived connection, a worker
thread owns the handle, playback-state changes arrive over a channel and
are coalesced — same shape as the Windows worker):

- **Preferred: `org.freedesktop.portal.Inhibit`** with `SUSPEND | IDLE`.
  The portal backends translate those flags into each desktop's native
  inhibitions — on KDE, PowerDevil `InterruptSession + ChangeScreenSettings`;
  on GNOME, a gnome-session idle+suspend inhibit — so one call is correct
  on both. Reachable from inside the Flatpak sandbox with no extra
  permission. Probed by reading the interface's `version` property, so no
  transient inhibition is taken.
- **Fallback: `org.freedesktop.ScreenSaver`** for sessions without a
  working portal. This is strictly weaker on KDE: kscreenlocker maps it
  to `ChangeScreenSettings` only, so it stops screen-blanking and the
  lock but not automatic suspend. GNOME treats it as a full idle inhibit,
  so it is equivalent there.

Verified on KDE Plasma 6 by tracing the session bus: during playback the
app holds PowerDevil policy 5 (`InterruptSession | ChangeScreenSettings`)
and `HasInhibition(ChangeScreenSettings)` is true, so screen-off is
suppressed too; pausing releases it and resuming re-takes it. `cargo fmt`
and `clippy` (pedantic) are clean and the `now_playing` unit tests pass.
